### PR TITLE
fix DISABLED_STRING bug

### DIFF
--- a/protobuf_serialization/internal.nim
+++ b/protobuf_serialization/internal.nim
@@ -44,9 +44,6 @@ type
   #Disabled types.
   Disabled = LUIntWrapped or array or cstring or tuple or Table
 
-const DISABLED_STRING = "Arrays, cstrings, tuples, and Tables are not serializable due to various reasons."
-discard DISABLED_STRING
-
 template isPotentiallyNull*[T](ty: typedesc[T]): bool =
   T is (Option or PBOption or ref or ptr)
 
@@ -197,6 +194,7 @@ func verifySerializable*[T](ty: typedesc[T]) {.compileTime.} =
   elif T is LUIntWrapped:
     {.fatal: "LibP2P VarInts are only usable directly with encodeVarInt.".}
   elif T is Disabled:
+    const DISABLED_STRING = "Arrays, cstrings, tuples, and Tables are not serializable due to various reasons."
     {.fatal: DISABLED_STRING & " are not serializable due to various reasons.".}
   elif T.isStdlib():
     discard

--- a/protobuf_serialization/internal.nim
+++ b/protobuf_serialization/internal.nim
@@ -195,7 +195,7 @@ func verifySerializable*[T](ty: typedesc[T]) {.compileTime.} =
     {.fatal: "LibP2P VarInts are only usable directly with encodeVarInt.".}
   elif T is Disabled:
     const DISABLED_STRING = "Arrays, cstrings, tuples, and Tables are not serializable due to various reasons."
-    {.fatal: DISABLED_STRING & " are not serializable due to various reasons.".}
+    {.fatal: DISABLED_STRING.}
   elif T.isStdlib():
     discard
   #Tuple inclusion is so in case we can add back support for tuples, we solely have to delete the above case.


### PR DESCRIPTION
before this fix, it produce wrong error message: 

```bash
Error: undeclared identifier: 'DISABLED_STRING'
```

now:
```bash
Error: Arrays, cstrings, tuples, and Tables are not serializable due to various reasons. are not serializable due to various reasons.
```