### PR TITLE
Fix enum range defect

### DIFF
--- a/protobuf_serialization/numbers/varint.nim
+++ b/protobuf_serialization/numbers/varint.nim
@@ -1,4 +1,4 @@
-import stew/bitops2
+import stew/[bitops2, objects]
 import faststreams
 
 import common
@@ -197,14 +197,20 @@ func decodeBinaryValue[E](
     res = E(value)
 
   elif E is PIntWrapped:
-    if len == 10:
-      when E is enum:
-        type S = int
-      else:
-        type S = type(res.unwrap())
-      res = E((-S(value)) - 1)
+    when E is enum:
+      type S = int
+      let enumValue = if len == 10:
+          (-S(value)) - 1
+        else:
+          S(value)
+      if not checkedEnumAssign(res, enumValue):
+        raise newException(ProtobufMessageError, "Attempted to decode an invalid enum value.")
     else:
-      res = E(value)
+      if len == 10:
+        type S = type(res.unwrap())
+        res = E((-S(value)) - 1)
+      else:
+        res = E(value)
 
   elif E is SIntWrapped:
     type S = type(res.unwrap())


### PR DESCRIPTION
A fix to raise ProtobufMessageError instead of RangeDefect when decoding an out-of-bound value for an enum in an object.
This work with enum with holes aswell.
```nim
type
  E = enum
    A1 = 1, A2 = 2, A3 = 3
  O {.protobuf3.} = object
    e {.fieldNumber: 1.}: E

expect ProtobufMessageError: Protobuf.decode(@[], type(X))
expect ProtobufMessageError: Protobuf.decode(@[8.byte, 4], type(X))
```

Blocked by #22 and by extension by [this issue](https://github.com/status-im/nim-faststreams/issues/31)