### PR TITLE
Add enum support

### DIFF
--- a/protobuf_serialization/codec.nim
+++ b/protobuf_serialization/codec.nim
@@ -54,19 +54,20 @@ type
   sfixed64* = distinct int64 ## fixed-width signed integer
 
   pbool* = distinct bool
+  penum* = distinct int32
 
   pstring* = distinct string ## UTF-8-encoded string
   pbytes* = distinct seq[byte] ## byte sequence
 
   SomeScalar* =
-    pint32 | pint64 | puint32 | puint64 | sint32 | sint64 | pbool |
+    pint32 | pint64 | puint32 | puint64 | sint32 | sint64 | pbool | penum |
     fixed64 | sfixed64 | pdouble |
     pstring | pbytes |
     fixed32 | sfixed32 | pfloat
 
   # Mappings of proto type to wire type
   SomeVarint* =
-    pint32 | pint64 | puint32 | puint64 | sint32 | sint64 | pbool
+    pint32 | pint64 | puint32 | puint64 | sint32 | sint64 | pbool | penum
   SomeFixed64* = fixed64 | sfixed64 | pdouble
   SomeLengthDelim* = pstring | pbytes # Also messages and packed repeated fields
   SomeFixed32* = fixed32 | sfixed32 | pfloat
@@ -116,6 +117,7 @@ func toUleb(x: sint32): uint32 =
 template toUleb(x: pint64): uint64 = cast[uint64](x)
 template toUleb(x: pint32): uint32 = cast[uint32](x)
 template toUleb(x: pbool): uint8 = cast[uint8](x)
+template toUleb(x: penum): uint64 = cast[uint32](x)
 
 template fromUleb(x: uint64, T: type puint64): T = puint64(x)
 template fromUleb(x: uint64, T: type pbool): T = pbool(x != 0)
@@ -130,6 +132,7 @@ template fromUleb(x: uint64, T: type sint32): T =
 
 template fromUleb(x: uint64, T: type pint64): T = cast[T](x)
 template fromUleb(x: uint64, T: type pint32): T = cast[T](x)
+template fromUleb(x: uint64, T: type penum): T = cast[T](x)
 
 template toBytes*(x: SomeVarint): openArray[byte] =
   toBytes(toUleb(x), Leb128).toOpenArray()

--- a/protobuf_serialization/internal.nim
+++ b/protobuf_serialization/internal.nim
@@ -91,6 +91,8 @@ template protoType*(InnerType, RootType, FieldType: untyped, fieldName: untyped)
     type InnerType = pstring
   elif FlatType is seq[byte]:
     type InnerType = pbytes
+  elif FlatType is enum:
+    type InnerType = penum
   elif FlatType is object:
     type InnerType = FieldType
   else:

--- a/protobuf_serialization/reader.nim
+++ b/protobuf_serialization/reader.nim
@@ -49,6 +49,8 @@ proc readFieldInto[T: enum](
   header: FieldHeader,
   ProtoType: type
 ) =
+  when 0 notin T:
+    {.fatal: $T & " definition must contain a constant that maps to zero".}
   header.requireKind(WireKind.Varint)
   let enumValue = stream.readValue(ProtoType)
   if not checkedEnumAssign(value, enumValue.int32):

--- a/protobuf_serialization/reader.nim
+++ b/protobuf_serialization/reader.nim
@@ -53,7 +53,8 @@ proc readFieldInto[T: enum](
     {.fatal: $T & " definition must contain a constant that maps to zero".}
   header.requireKind(WireKind.Varint)
   let enumValue = stream.readValue(ProtoType)
-  if not checkedEnumAssign(value, enumValue.int32):
+  if not checkedEnumAssign(value, enumValue.int32) and
+    not checkedEnumAssign(value, 0):
     raise (ref ValueError)(msg: "Attempted to decode an invalid enum value")
 
 proc readFieldInto[T: not object and not enum and (seq[byte] or not seq)](

--- a/protobuf_serialization/writer.nim
+++ b/protobuf_serialization/writer.nim
@@ -28,7 +28,7 @@ proc writeField[T: object and not PBOption](
     stream: OutputStream, fieldNum: int, fieldVal: T, ProtoType: type) =
   stream.writeField(fieldNum, fieldVal)
 
-proc writeField[T: not object](
+proc writeField[T: not object and not enum](
     stream: OutputStream, fieldNum: int, fieldVal: T, ProtoType: type) =
   stream.writeField(fieldNum, ProtoType(fieldVal))
 
@@ -36,6 +36,10 @@ proc writeField(
     stream: OutputStream, fieldNum: int, fieldVal: PBOption, ProtoType: type) =
   if fieldVal.isSome(): # TODO required field checking
     stream.writeField(fieldNum, fieldVal.get(), ProtoType)
+
+proc writeField[T: enum](
+    stream: OutputStream, fieldNum: int, fieldVal: T, ProtoType: type) =
+  stream.writeField(fieldNum, pint32(fieldVal.ord()))
 
 proc writeFieldPacked*[T: not byte, ProtoType: SomePrimitive](
     output: OutputStream, field: int, values: openArray[T], _: type ProtoType) =

--- a/protobuf_serialization/writer.nim
+++ b/protobuf_serialization/writer.nim
@@ -39,6 +39,8 @@ proc writeField(
 
 proc writeField[T: enum](
     stream: OutputStream, fieldNum: int, fieldVal: T, ProtoType: type) =
+  when 0 notin T:
+    {.fatal: $T & " definition must contain a constant that maps to zero".}
   stream.writeField(fieldNum, pint32(fieldVal.ord()))
 
 proc writeFieldPacked*[T: not byte, ProtoType: SomePrimitive](

--- a/protobuf_serialization/writer.nim
+++ b/protobuf_serialization/writer.nim
@@ -3,6 +3,7 @@
 import
   std/typetraits,
   stew/shims/macros,
+  stew/objects,
   faststreams/outputs,
   serialization,
   "."/[codec, internal, types]

--- a/tests/test_enum.nim
+++ b/tests/test_enum.nim
@@ -70,8 +70,10 @@ suite "Test Enum Encoding/Decoding":
       check Protobuf.decode(encodedp2, ObjLimitsP2) == objp2
       check Protobuf.decode(encodedp3, ObjLimitsP3) == objp3
 
-  test "Cannot decode out of range enum":
-    expect ValueError: discard Protobuf.decode(@[8'u8, 4], ObjWithHolesP2) # Inside the hole
-    expect ValueError: discard Protobuf.decode(@[8'u8, 4], ObjWithHolesP3) # Inside the hole
-    expect ValueError: discard Protobuf.decode(@[8'u8, 24], ObjWithHolesP2) # Outside the hole
-    expect ValueError: discard Protobuf.decode(@[8'u8, 24], ObjWithHolesP3) # Outside the hole
+  test "Decode out of range enum":
+    # TODO: Find a way to save the unrecognized value
+    check:
+      Protobuf.decode(@[8'u8, 4], ObjWithHolesP2) == ObjWithHolesP2() # Inside the hole
+      Protobuf.decode(@[8'u8, 4], ObjWithHolesP3) == ObjWithHolesP3() # Inside the hole
+      Protobuf.decode(@[8'u8, 24], ObjWithHolesP2) == ObjWithHolesP2() # Outside the hole
+      Protobuf.decode(@[8'u8, 24], ObjWithHolesP3) == ObjWithHolesP3() # Outside the hole

--- a/tests/test_enum.nim
+++ b/tests/test_enum.nim
@@ -1,0 +1,77 @@
+import unittest2
+
+import
+  ../protobuf_serialization,
+  ../protobuf_serialization/codec
+
+type
+  Classic = enum
+    A1
+    B1
+    C1
+
+  WithHoles = enum
+    A2 = -10
+    B2 = 0
+    C2 = 10
+    D2
+
+  Limits = enum
+    A3 = int32.low()
+    B3 = 0
+    C3 = int32.high()
+
+  ObjClassicP2 {.proto2.} = object
+    x {.fieldNumber: 1, required.}: Classic
+
+  ObjWithHolesP2 {.proto2.} = object
+    x {.fieldNumber: 1, required.}: WithHoles
+
+  ObjLimitsP2 {.proto2.} = object
+    x {.fieldNumber: 1, required.}: Limits
+
+  ObjClassicP3 {.proto3.} = object
+    x {.fieldNumber: 1.}: Classic
+
+  ObjWithHolesP3 {.proto3.} = object
+    x {.fieldNumber: 1.}: WithHoles
+
+  ObjLimitsP3 {.proto3.} = object
+    x {.fieldNumber: 1.}: Limits
+
+suite "Test Enum Encoding/Decoding":
+  test "Can encode/decode enum":
+    for x in @[A1, B1, C1]:
+      let
+        objp2 = ObjClassicP2(x: x)
+        objp3 = ObjClassicP3(x: x)
+        encodedp2 = Protobuf.encode(objp2)
+        encodedp3 = Protobuf.encode(objp3)
+      check Protobuf.decode(encodedp2, ObjClassicP2) == objp2
+      check Protobuf.decode(encodedp3, ObjClassicP3) == objp3
+
+  test "Can encode/decode enum with holes":
+    for x in @[A2, B2, C2, D2]:
+      let
+        objp2 = ObjWithHolesP2(x: x)
+        objp3 = ObjWithHolesP3(x: x)
+        encodedp2 = Protobuf.encode(objp2)
+        encodedp3 = Protobuf.encode(objp3)
+      check Protobuf.decode(encodedp2, ObjWithHolesP2) == objp2
+      check Protobuf.decode(encodedp3, ObjWithHolesP3) == objp3
+
+  test "Can encode/decode enum limits":
+    for x in @[A3, B3, C3]:
+      let
+        objp2 = ObjLimitsP2(x: x)
+        objp3 = ObjLimitsP3(x: x)
+        encodedp2 = Protobuf.encode(objp2)
+        encodedp3 = Protobuf.encode(objp3)
+      check Protobuf.decode(encodedp2, ObjLimitsP2) == objp2
+      check Protobuf.decode(encodedp3, ObjLimitsP3) == objp3
+
+  test "Cannot decode out of range enum":
+    expect ValueError: discard Protobuf.decode(@[8'u8, 4], ObjWithHolesP2) # Inside the hole
+    expect ValueError: discard Protobuf.decode(@[8'u8, 4], ObjWithHolesP3) # Inside the hole
+    expect ValueError: discard Protobuf.decode(@[8'u8, 24], ObjWithHolesP2) # Outside the hole
+    expect ValueError: discard Protobuf.decode(@[8'u8, 24], ObjWithHolesP3) # Outside the hole

--- a/tests/test_objects.nim
+++ b/tests/test_objects.nim
@@ -5,6 +5,11 @@ import
   ../protobuf_serialization/codec
 
 type
+  TestEnum = enum
+    A1 = 0
+    B1 = 1000
+    C1 = 1000000
+
   Basic {.proto3.} = object
     a {.fieldNumber: 1, pint.}: uint64
     b {.fieldNumber: 2.}: string
@@ -16,6 +21,7 @@ type
     f {.fieldNumber: 3.}: Basic
     g {.fieldNumber: 4.}: string
     h {.fieldNumber: 5.}: bool
+    i {.fieldNumber: 6.}: TestEnum
 
 discard Protobuf.supports(Basic)
 discard Protobuf.supports(Wrapped)
@@ -34,7 +40,8 @@ suite "Test Object Encoding/Decoding":
       e: 200,
       f: Basic(a: 100, b: "Test string."), # TODO, c: 'C'),
       g: "Other test string.",
-      h: true
+      h: true,
+      i: A1
     )
     check Protobuf.decode(Protobuf.encode(obj), type(Wrapped)) == obj
 
@@ -45,7 +52,8 @@ suite "Test Object Encoding/Decoding":
         e: 200,
         f: Basic(a: 100, b: "Test string."), # c: 'C'),
         g: "Other test string.",
-        h: true
+        h: true,
+        i: B1
       )
       writer = memoryOutput()
 
@@ -67,11 +75,13 @@ suite "Test Object Encoding/Decoding":
         e: 200,
         f: Basic(a: 100, b: "Test string."), # c: 'C'),
         g: "Other test string.",
-        h: true
+        h: true,
+        i: C1
       )
       writer = memoryOutput()
 
     writer.writeField(3, obj.f)
+    writer.writeField(6, penum(obj.i))
     writer.writeField(1, sint64(obj.d))
     writer.writeField(2, sint64(obj.e))
     writer.writeField(5, pbool(obj.h))


### PR DESCRIPTION
Things left to do:
- [ ] option allow_alias (waiting for #41 before looking at it)
- [ ] reserved values (idem, waiting for #41)
- [ ] save unrecognized values during deserialization

For the last point, it might be hard with the way nim works with enum:
```nim
type
  Test = enum
    A = 0
    B = 10

echo Test(parseInt("10")) # print "B"
echo Test(parseInt("5"))  # print "5 (invalid data!)"
echo Test(parseInt("15")) # crash with 15 notin 0 .. 10 [RangeDefect]
```
So for now, I set the enum at the default value if it isn't recognized.