### PR TITLE
Fix conformance test

### DIFF
--- a/protobuf_serialization/codec.nim
+++ b/protobuf_serialization/codec.nim
@@ -75,7 +75,7 @@ type
     ## Types that may appear packed
 
 const
-  GroupsWireKinds = {
+  GroupWireKinds = {
     3'u8, 4'u8  # StartGroup, EndGroup
   }
   SupportedWireKinds* = {
@@ -261,8 +261,8 @@ proc readHeader*(input: InputStream): FieldHeader {.raises: [SerializationError,
     hdr = uint32(input.readValue(puint32))
     wire = uint8(hdr and 0x07)
 
-  if wire in GroupsWireKinds:
-    raise (ref ProtobufGroupsError)(msg: "Unsupported wire type " & $wire)
+  if wire in GroupWireKinds:
+    raise (ref ProtobufGroupError)(msg: "Unsupported wire type " & $wire)
 
   if wire notin SupportedWireKinds:
     raise (ref ProtobufValueError)(msg: "Invalid wire type " & $wire)

--- a/protobuf_serialization/codec.nim
+++ b/protobuf_serialization/codec.nim
@@ -24,8 +24,8 @@ type
     Varint = 0
     Fixed64 = 1
     LengthDelim = 2
-    # StartGroup = 3 # Not used
-    # EndGroup = 4 # Not used
+    StartGroup = 3
+    EndGroup = 4
     Fixed32 = 5
 
   SomePBInt* = int32 | int64 | uint32 | uint64
@@ -75,6 +75,10 @@ type
     ## Types that may appear packed
 
 const
+  UnsupportedWireKinds = {
+    uint8(WireKind.StartGroup),
+    uint8(WireKind.EndGroup)
+  }
   SupportedWireKinds* = {
     uint8(WireKind.Varint),
     uint8(WireKind.Fixed64),
@@ -257,6 +261,9 @@ proc readHeader*(input: InputStream): FieldHeader {.raises: [SerializationError,
   let
     hdr = uint32(input.readValue(puint32))
     wire = uint8(hdr and 0x07)
+
+  if wire in UnsupportedWireKinds:
+    raise (ref ProtobufUnsupportedWireTypeError)(msg: "Unsupported wire type " & $wire)
 
   if wire notin SupportedWireKinds:
     raise (ref ProtobufValueError)(msg: "Invalid wire type " & $wire)

--- a/protobuf_serialization/codec.nim
+++ b/protobuf_serialization/codec.nim
@@ -75,7 +75,7 @@ type
     ## Types that may appear packed
 
 const
-  UnsupportedWireKinds = {
+  GroupsWireKinds = {
     3'u8, 4'u8  # StartGroup, EndGroup
   }
   SupportedWireKinds* = {
@@ -261,7 +261,7 @@ proc readHeader*(input: InputStream): FieldHeader {.raises: [SerializationError,
     hdr = uint32(input.readValue(puint32))
     wire = uint8(hdr and 0x07)
 
-  if wire in UnsupportedWireKinds:
+  if wire in GroupsWireKinds:
     raise (ref ProtobufGroupsError)(msg: "Unsupported wire type " & $wire)
 
   if wire notin SupportedWireKinds:

--- a/protobuf_serialization/codec.nim
+++ b/protobuf_serialization/codec.nim
@@ -262,7 +262,7 @@ proc readHeader*(input: InputStream): FieldHeader {.raises: [SerializationError,
     wire = uint8(hdr and 0x07)
 
   if wire in UnsupportedWireKinds:
-    raise (ref ProtobufUnsupportedWireTypeError)(msg: "Unsupported wire type " & $wire)
+    raise (ref ProtobufGroupsError)(msg: "Unsupported wire type " & $wire)
 
   if wire notin SupportedWireKinds:
     raise (ref ProtobufValueError)(msg: "Invalid wire type " & $wire)

--- a/protobuf_serialization/codec.nim
+++ b/protobuf_serialization/codec.nim
@@ -24,8 +24,8 @@ type
     Varint = 0
     Fixed64 = 1
     LengthDelim = 2
-    StartGroup = 3
-    EndGroup = 4
+    # StartGroup = 3 # Not used
+    # EndGroup = 4 # Not used
     Fixed32 = 5
 
   SomePBInt* = int32 | int64 | uint32 | uint64
@@ -76,8 +76,7 @@ type
 
 const
   UnsupportedWireKinds = {
-    uint8(WireKind.StartGroup),
-    uint8(WireKind.EndGroup)
+    3'u8, 4'u8  # StartGroup, EndGroup
   }
   SupportedWireKinds* = {
     uint8(WireKind.Varint),

--- a/protobuf_serialization/types.nim
+++ b/protobuf_serialization/types.nim
@@ -15,7 +15,7 @@ type
   ProtobufEOFError* = object of ProtobufReadError
   ProtobufMessageError* = object of ProtobufReadError
   ProtobufValueError* = object of ProtobufReadError
-  ProtobufUnsupportedWireTypeError* = object of ProtobufValueError
+  ProtobufGroupsError* = object of ProtobufValueError
 
   ProtobufFlags* = enum
     VarIntLengthPrefix

--- a/protobuf_serialization/types.nim
+++ b/protobuf_serialization/types.nim
@@ -15,6 +15,7 @@ type
   ProtobufEOFError* = object of ProtobufReadError
   ProtobufMessageError* = object of ProtobufReadError
   ProtobufValueError* = object of ProtobufReadError
+  ProtobufUnsupportedWireTypeError* = object of ProtobufValueError
 
   ProtobufFlags* = enum
     VarIntLengthPrefix

--- a/protobuf_serialization/types.nim
+++ b/protobuf_serialization/types.nim
@@ -15,7 +15,7 @@ type
   ProtobufEOFError* = object of ProtobufReadError
   ProtobufMessageError* = object of ProtobufReadError
   ProtobufValueError* = object of ProtobufReadError
-  ProtobufGroupsError* = object of ProtobufValueError
+  ProtobufGroupError* = object of ProtobufValueError
 
   ProtobufFlags* = enum
     VarIntLengthPrefix

--- a/tests/conformance/conformance_nim.nim
+++ b/tests/conformance/conformance_nim.nim
@@ -17,7 +17,7 @@ proc writeIntLE(v: int32) =
 
 template processPayload(payload, DecodeType): untyped =
   try:
-    let x = Protobuf.decode(payload, TestAllTypesProto3)
+    let x = Protobuf.decode(payload, DecodeType)
     try:
       ConformanceResponse(protobuf_payload: Protobuf.encode(x))
     except ProtobufError as exc:

--- a/tests/conformance/conformance_nim.nim
+++ b/tests/conformance/conformance_nim.nim
@@ -22,7 +22,7 @@ template processPayload(payload, DecodeType): untyped =
       ConformanceResponse(protobuf_payload: Protobuf.encode(x))
     except ProtobufError as exc:
       ConformanceResponse(serialize_error: "serialize_error: " & exc.msg)
-  except ProtobufGroupsError as exc:
+  except ProtobufGroupError as exc:
     ConformanceResponse(skipped: "skipped: " & exc.msg)
   except ProtobufError as exc:
     ConformanceResponse(parse_error: "parse_error: " & exc.msg)

--- a/tests/conformance/conformance_nim.nim
+++ b/tests/conformance/conformance_nim.nim
@@ -22,7 +22,7 @@ template processPayload(payload, DecodeType): untyped =
       ConformanceResponse(protobuf_payload: Protobuf.encode(x))
     except ProtobufError as exc:
       ConformanceResponse(serialize_error: "serialize_error: " & exc.msg)
-  except ProtobufUnsupportedWireTypeError as exc:
+  except ProtobufGroupsError as exc:
     ConformanceResponse(skipped: "skipped: " & exc.msg)
   except ProtobufError as exc:
     ConformanceResponse(parse_error: "parse_error: " & exc.msg)

--- a/tests/conformance/conformance_nim.nim
+++ b/tests/conformance/conformance_nim.nim
@@ -21,7 +21,7 @@ template processPayload(payload, DecodeType): untyped =
     try:
       ConformanceResponse(protobuf_payload: Protobuf.encode(x))
     except ProtobufError as exc:
-      ConformanceResponse(serialize_error: "skipped: " & exc.msg)
+      ConformanceResponse(serialize_error: "serialize_error: " & exc.msg)
   except ProtobufUnsupportedWireTypeError as exc:
     ConformanceResponse(skipped: "skipped: " & exc.msg)
   except ProtobufError as exc:

--- a/tests/conformance/conformance_nim.nim
+++ b/tests/conformance/conformance_nim.nim
@@ -15,6 +15,29 @@ proc writeIntLE(v: int32) =
   if stdout.writeBuffer(addr(value), 4) != 4:
     raise newException(IOError, "writeInt error")
 
+template processPayload(payload, DecodeType): untyped =
+  try:
+    let x = Protobuf.decode(payload, TestAllTypesProto3)
+    try:
+      ConformanceResponse(protobuf_payload: Protobuf.encode(x))
+    except ProtobufError as exc:
+      ConformanceResponse(serialize_error: "skipped: " & exc.msg)
+  except ProtobufUnsupportedWireTypeError as exc:
+    ConformanceResponse(skipped: "skipped: " & exc.msg)
+  except ProtobufError as exc:
+    ConformanceResponse(parse_error: "parse_error: " & exc.msg)
+
+proc doTest(request: ConformanceRequest): ConformanceResponse =
+  if request.requested_output_format != WireFormat.PROTOBUF or
+      request.protobuf_payload.len() == 0:
+    ConformanceResponse(skipped: "skip not protobuf")
+  elif request.message_type == "protobuf_test_messages.proto3.TestAllTypesProto3":
+    processPayload(request.protobuf_payload, TestAllTypesProto3)
+  elif request.message_type == "protobuf_test_messages.proto2.TestAllTypesProto2":
+    processPayload(request.protobuf_payload, TestAllTypesProto2)
+  else:
+    ConformanceResponse(skipped: "skip unknown message type: " & request.message_type)
+
 proc doTest(): bool =
   let length =
     try: readIntLE()
@@ -25,35 +48,13 @@ proc doTest(): bool =
     raise newException(IOError, "IProtobuf./O error")
 
   let request = Protobuf.decode(serializedRequest, ConformanceRequest)
-
-  var response = ConformanceResponse()
-
-  if request.requested_output_format != WireFormat.PROTOBUF or
-      request.protobuf_payload.len() == 0:
-    response.skipped = "skip not protobuf"
-  else:
-    try:
-      if request.message_type == "protobuf_test_messages.proto3.TestAllTypesProto3":
-        let x = Protobuf.decode(request.protobuf_payload, TestAllTypesProto3)
-        response.protobuf_payload = Protobuf.encode(x)
-      elif request.message_type == "protobuf_test_messages.proto2.TestAllTypesProto2":
-        let x = Protobuf.decode(request.protobuf_payload, TestAllTypesProto2)
-        response.protobuf_payload = Protobuf.encode(x)
-      else:
-        response.skipped = "skip unknown message type: " & request.message_type
-    except CatchableError as exc:
-      # TODO better error reporting instead of skipping
-      # response.parse_error = exc.msg
-      response.skipped = exc.msg
-
-  let serializedResponse = Protobuf.encode(response)
+  let serializedResponse = Protobuf.encode(doTest(request))
 
   writeIntLE(serializedResponse.len().int32)
 
   stdout.write(string.fromBytes(serializedResponse))
   stdout.flushFile()
   true
-
 
 try:
   while doTest():

--- a/tests/conformance/failure_list.txt
+++ b/tests/conformance/failure_list.txt
@@ -348,7 +348,6 @@ Required.Proto3.ProtobufInput.RepeatedScalarSelectsLast.SINT64.ProtobufOutput
 Required.Proto3.ProtobufInput.RepeatedScalarSelectsLast.STRING.ProtobufOutput
 Required.Proto3.ProtobufInput.RepeatedScalarSelectsLast.UINT32.ProtobufOutput
 Required.Proto3.ProtobufInput.RepeatedScalarSelectsLast.UINT64.ProtobufOutput
-Required.Proto3.ProtobufInput.UnknownOrdering.ProtobufOutput
 Required.Proto3.ProtobufInput.UnknownVarint.ProtobufOutput
 Required.Proto3.ProtobufInput.ValidDataMap.BOOL.BOOL.Default.ProtobufOutput
 Required.Proto3.ProtobufInput.ValidDataMap.BOOL.BOOL.DuplicateKey.ProtobufOutput

--- a/tests/test_all.nim
+++ b/tests/test_all.nim
@@ -6,6 +6,7 @@ import
   test_bool,
   test_codec,
   test_fixed,
+  test_groups,
   test_objects,
   test_empty,
   test_repeated,

--- a/tests/test_groups.nim
+++ b/tests/test_groups.nim
@@ -1,0 +1,21 @@
+import unittest2
+
+import ../protobuf_serialization
+
+type
+  Dummy {.proto3.} = object
+
+suite "Test Group Decoding":
+  test "decode start group is not supported":
+    let encoded = @[byte(0x0B)]
+    expect(ProtobufUnsupportedWireTypeError):
+      discard Protobuf.decode(encoded, Dummy)
+    expect(ProtobufValueError):
+      discard Protobuf.decode(encoded, Dummy)
+
+  test "decode end group is not supported":
+    let encoded = @[byte(0x0C)]
+    expect(ProtobufUnsupportedWireTypeError):
+      discard Protobuf.decode(encoded, Dummy)
+    expect(ProtobufValueError):
+      discard Protobuf.decode(encoded, Dummy)

--- a/tests/test_groups.nim
+++ b/tests/test_groups.nim
@@ -8,14 +8,14 @@ type
 suite "Test Group Decoding":
   test "decode start group is not supported":
     let encoded = @[byte(0x0B)]
-    expect(ProtobufUnsupportedWireTypeError):
+    expect(ProtobufGroupsError):
       discard Protobuf.decode(encoded, Dummy)
     expect(ProtobufValueError):
       discard Protobuf.decode(encoded, Dummy)
 
   test "decode end group is not supported":
     let encoded = @[byte(0x0C)]
-    expect(ProtobufUnsupportedWireTypeError):
+    expect(ProtobufGroupsError):
       discard Protobuf.decode(encoded, Dummy)
     expect(ProtobufValueError):
       discard Protobuf.decode(encoded, Dummy)

--- a/tests/test_groups.nim
+++ b/tests/test_groups.nim
@@ -8,14 +8,14 @@ type
 suite "Test Group Decoding":
   test "decode start group is not supported":
     let encoded = @[byte(0x0B)]
-    expect(ProtobufGroupsError):
+    expect(ProtobufGroupError):
       discard Protobuf.decode(encoded, Dummy)
     expect(ProtobufValueError):
       discard Protobuf.decode(encoded, Dummy)
 
   test "decode end group is not supported":
     let encoded = @[byte(0x0C)]
-    expect(ProtobufGroupsError):
+    expect(ProtobufGroupError):
       discard Protobuf.decode(encoded, Dummy)
     expect(ProtobufValueError):
       discard Protobuf.decode(encoded, Dummy)


### PR DESCRIPTION
The conformance test catches all exceptions and skip failures which won't catch regressions. This also skipped negative tests.

Changes:

- Fix conformance test so decode/encode exceptions send a parser/serialize error instead of skipping them.
- Add `ProtobufGroupError`, raised when the data contains start/end groups. Skip this error in the conformance test.

HEAD:

```
CONFORMANCE SUITE PASSED: 29 successes, 1823 skipped, 514 expected failures, 0 unexpected failures.
```

This PR:

```
CONFORMANCE SUITE PASSED: 333 successes, 1403 skipped, 598 expected failures, 0 unexpected failures.
```

Note expected failures matches the number of failures in the failures file.