### PR TITLE
Avoid writing repeated packed default in proto3

### DIFF
--- a/protobuf_serialization/sizer.nim
+++ b/protobuf_serialization/sizer.nim
@@ -82,9 +82,13 @@ proc computeSizePacked*[T: not byte, ProtoType: SomePrimitive](
     total
 
 proc computeFieldSizePacked*[ProtoType: SomePrimitive](
-    field: int, values: openArray, _: type ProtoType): int =
+    field: int, values: openArray, _: type ProtoType,
+    skipDefault: static bool): int =
   # Packed encoding uses a length-delimited field byte length of the sum of the
   # byte lengths of each field followed by the header-free contents
+  when skipDefault:
+    if values.len == 0:
+      return 0
   let
     dataSize = computeSizePacked(values, ProtoType)
 
@@ -113,7 +117,7 @@ func computeObjectSize*[T: object](value: T): int =
       const
         isPacked = T.isPacked(fieldName).get(isProto3)
       when isPacked and ProtoType is SomePrimitive:
-        computeFieldSizePacked(fieldNum, fieldVal, ProtoType)
+        computeFieldSizePacked(fieldNum, fieldVal, ProtoType, isProto3)
       else:
         var dataSize = 0
         for i in 0..<fieldVal.len:

--- a/protobuf_serialization/writer.nim
+++ b/protobuf_serialization/writer.nim
@@ -51,9 +51,14 @@ proc writeField*(
     stream.writeField(fieldNum, fieldVal.get(), ProtoType, skipDefault)
 
 proc writeFieldPacked*[T: not byte, ProtoType: SomePrimitive](
-    output: OutputStream, field: int, values: openArray[T], _: type ProtoType) {.raises: [IOError].} =
+    output: OutputStream, field: int, values: openArray[T], _: type ProtoType,
+    skipDefault: static bool = false) {.raises: [IOError].} =
   # Packed encoding uses a length-delimited field byte length of the sum of the
   # byte lengths of each field followed by the header-free contents
+  when skipDefault:
+    if values.len == 0:
+      return
+
   output.write(
     toBytes(FieldHeader.init(field, WireKind.LengthDelim)))
 
@@ -118,7 +123,7 @@ proc writeObject[T: object](stream: OutputStream, value: T) {.raises: [IOError].
       const
         isPacked = T.isPacked(fieldName).get(isProto3)
       when isPacked and ProtoType is SomePrimitive:
-        stream.writeFieldPacked(fieldNum, fieldVal, ProtoType)
+        stream.writeFieldPacked(fieldNum, fieldVal, ProtoType, isProto3)
       else:
         for i in 0..<fieldVal.len:
           # don't skip defaults so as to preserve length

--- a/tests/conformance/conformance_nim.nim
+++ b/tests/conformance/conformance_nim.nim
@@ -48,7 +48,13 @@ proc doTest(): bool =
     raise newException(IOError, "IProtobuf./O error")
 
   let request = Protobuf.decode(serializedRequest, ConformanceRequest)
-  let serializedResponse = Protobuf.encode(doTest(request))
+  let response = doTest(request)
+  let serializedResponse = if response == default(ConformanceResponse):
+    # XXX: remove once oneof is supported;
+    #      this is field 3 set to an empty seq
+    "1a00".hexToSeqByte
+  else:
+    Protobuf.encode(response)
 
   writeIntLE(serializedResponse.len().int32)
 

--- a/tests/test_repeated.nim
+++ b/tests/test_repeated.nim
@@ -38,6 +38,9 @@ z: ["zero", "one", "two"]
       Protobuf.encode(v) == encoded
       Protobuf.decode(encoded, typeof(v)) == v
 
+  test "Empty sequences":
+    check Protobuf.encode(Sequences()).len == 0
+
   test "Packed sequences":
     # protoc --encode=Packed test_repeated.proto | hexdump -ve '1/1 "%.2x"'
     discard """
@@ -60,3 +63,6 @@ a: [5, -3, 300, -612]
       Protobuf.computeSize(v) == encoded.len
       Protobuf.encode(v) == encoded
       Protobuf.decode(encoded, typeof(v)) == v
+
+  test "Empty packed sequences":
+    check Protobuf.encode(Packed()).len == 0

--- a/tests/test_repeated.nim
+++ b/tests/test_repeated.nim
@@ -39,7 +39,9 @@ z: ["zero", "one", "two"]
       Protobuf.decode(encoded, typeof(v)) == v
 
   test "Empty sequences":
-    check Protobuf.encode(Sequences()).len == 0
+    check:
+      Protobuf.computeSize(Sequences()) == 0
+      Protobuf.encode(Sequences()).len == 0
 
   test "Packed sequences":
     # protoc --encode=Packed test_repeated.proto | hexdump -ve '1/1 "%.2x"'
@@ -65,4 +67,6 @@ a: [5, -3, 300, -612]
       Protobuf.decode(encoded, typeof(v)) == v
 
   test "Empty packed sequences":
-    check Protobuf.encode(Packed()).len == 0
+    check:
+      Protobuf.computeSize(Packed()) == 0
+      Protobuf.encode(Packed()).len == 0


### PR DESCRIPTION
Changes:

- No longer write empty seq/repeated packed when it's empty
- Conformance test response can be empty now if everything is set to default; added a hack to set the response oneof field, can be removed once oneof is implemented #15

HEAD:

```
CONFORMANCE SUITE PASSED: 877 successes, 1367 skipped, 90 expected failures, 0 unexpected failures.
```

This PR:

```
CONFORMANCE SUITE PASSED: 1145 successes, 1367 skipped, 90 expected failures, 0 unexpected failures.
```