### PR TITLE
Avoid writing repeated packed default in proto2

### DIFF
--- a/protobuf_serialization/sizer.nim
+++ b/protobuf_serialization/sizer.nim
@@ -82,13 +82,11 @@ proc computeSizePacked*[T: not byte, ProtoType: SomePrimitive](
     total
 
 proc computeFieldSizePacked*[ProtoType: SomePrimitive](
-    field: int, values: openArray, _: type ProtoType,
-    skipDefault: static bool): int =
+    field: int, values: openArray, _: type ProtoType): int =
   # Packed encoding uses a length-delimited field byte length of the sum of the
   # byte lengths of each field followed by the header-free contents
-  when skipDefault:
-    if values.len == 0:
-      return 0
+  if values.len == 0:
+    return 0
   let
     dataSize = computeSizePacked(values, ProtoType)
 
@@ -117,7 +115,7 @@ func computeObjectSize*[T: object](value: T): int =
       const
         isPacked = T.isPacked(fieldName).get(isProto3)
       when isPacked and ProtoType is SomePrimitive:
-        computeFieldSizePacked(fieldNum, fieldVal, ProtoType, isProto3)
+        computeFieldSizePacked(fieldNum, fieldVal, ProtoType)
       else:
         var dataSize = 0
         for i in 0..<fieldVal.len:

--- a/protobuf_serialization/writer.nim
+++ b/protobuf_serialization/writer.nim
@@ -45,13 +45,11 @@ proc writeField*[T: not object and not enum](
   stream.writeField(fieldNum, ProtoType(fieldVal))
 
 proc writeFieldPacked*[T: not byte, ProtoType: SomePrimitive](
-    output: OutputStream, field: int, values: openArray[T], _: type ProtoType,
-    skipDefault: static bool = false) {.raises: [IOError].} =
+    output: OutputStream, field: int, values: openArray[T], _: type ProtoType) {.raises: [IOError].} =
   # Packed encoding uses a length-delimited field byte length of the sum of the
   # byte lengths of each field followed by the header-free contents
-  when skipDefault:
-    if values.len == 0:
-      return
+  if values.len == 0:
+    return
 
   output.write(
     toBytes(FieldHeader.init(field, WireKind.LengthDelim)))
@@ -123,7 +121,7 @@ proc writeObject[T: object](stream: OutputStream, value: T) {.raises: [IOError].
       const
         isPacked = T.isPacked(fieldName).get(isProto3)
       when isPacked and ProtoType is SomePrimitive:
-        stream.writeFieldPacked(fieldNum, fieldVal, ProtoType, isProto3)
+        stream.writeFieldPacked(fieldNum, fieldVal, ProtoType)
       else:
         for i in 0..<fieldVal.len:
           # don't skip defaults so as to preserve length


### PR DESCRIPTION
Changes:

- No longer write empty seq/repeated packed when it's empty in proto2

Related #59

HEAD
```
CONFORMANCE SUITE PASSED: 1077 successes, 1367 skipped, 89 expected failures, 0 unexpected failures.
```

This PR
```
CONFORMANCE SUITE PASSED: 1267 successes, 1367 skipped, 89 expected failures, 0 unexpected failures
```