### PR TITLE
Add `pbSome(value)` for `PBOption[default(T)]`

### DIFF
--- a/protobuf_serialization/types.nim
+++ b/protobuf_serialization/types.nim
@@ -89,6 +89,25 @@ func pbSome*[T: PBOption](optType: typedesc[T], value: auto): T {.inline.} =
     value: value
   )
 
+template fixedDefault(T): untyped =
+  when T is int64:
+    0'i64
+  elif T is int32:
+    0'i32
+  elif T is uint64:
+    0'u64
+  elif T is uint32:
+    0'u32
+  elif T is float64:
+    0'f64
+  elif T is float32:
+    0'f32
+  else:
+    default(T)
+
+template pbSome*(value: untyped): untyped =
+  pbSome(PBOption[fixedDefault(typeof(value))], value)
+
 func init*(opt: var PBOption, val: auto) =
   opt.some = true
   opt.value = val

--- a/tests/test_protobuf2_semantics.nim
+++ b/tests/test_protobuf2_semantics.nim
@@ -108,3 +108,16 @@ suite "Test Encoding of Protobuf 2 Semantics":
 
     var v = FixedOption(d: PBOption[0'u64].pbSome(1'u64))
     check Protobuf.decode(Protobuf.encode(v), FixedOption) == v
+
+  test "PBOption ergonomic":
+    check:
+      PBOption[0'i64].pbSome(1'i64) == pbSome(1'i64)
+      PBOption[0'i32].pbSome(1'i32) == pbSome(1'i32)
+      PBOption[0'u64].pbSome(1'u64) == pbSome(1'u64)
+      PBOption[0'u32].pbSome(1'u32) == pbSome(1'u32)
+      PBOption[0'f64].pbSome(1'f64) == pbSome(1'f64)
+      PBOption[0'f32].pbSome(1'f32) == pbSome(1'f32)
+      PBOption[false].pbSome(true) == pbSome(true)
+      PBOption[""].pbSome("abc") == pbSome("abc")
+      PBOption[default(seq[byte])].pbSome(@[1'u8]) == pbSome(@[1'u8])
+      PBOption[default(Required)].pbSome(Required()) == pbSome(Required())


### PR DESCRIPTION
Make pbSome a bit more ergonomic when type is `PBOption[default(T)]`.

Changes:

- Add `pbSome(value)` shortcut for `PBOption[default(T)].pbSome(value)`