### PR TITLE
Add `pbNone(default(T))`

### DIFF
--- a/protobuf_serialization/types.nim
+++ b/protobuf_serialization/types.nim
@@ -108,6 +108,9 @@ template fixedDefault(T): untyped =
 template pbSome*(value: untyped): untyped =
   pbSome(PBOption[fixedDefault(typeof(value))], value)
 
+template pbNone*(value: untyped): untyped =
+  PBOption[value]()
+
 func init*(opt: var PBOption, val: auto) =
   opt.some = true
   opt.value = val

--- a/tests/test_protobuf2_semantics.nim
+++ b/tests/test_protobuf2_semantics.nim
@@ -109,7 +109,7 @@ suite "Test Encoding of Protobuf 2 Semantics":
     var v = FixedOption(d: PBOption[0'u64].pbSome(1'u64))
     check Protobuf.decode(Protobuf.encode(v), FixedOption) == v
 
-  test "PBOption ergonomic":
+  test "pbSome ergonomic":
     check:
       PBOption[0'i64].pbSome(1'i64) == pbSome(1'i64)
       PBOption[0'i32].pbSome(1'i32) == pbSome(1'i32)
@@ -121,3 +121,9 @@ suite "Test Encoding of Protobuf 2 Semantics":
       PBOption[""].pbSome("abc") == pbSome("abc")
       PBOption[default(seq[byte])].pbSome(@[1'u8]) == pbSome(@[1'u8])
       PBOption[default(Required)].pbSome(Required()) == pbSome(Required())
+
+  test "pbNone ergonomic":
+    check:
+      pbNone("").isNone
+      PBOption[""]() == pbNone("")
+      PBOption[default(Required)]() == pbNone(default(Required))


### PR DESCRIPTION
Changes:

- Add `pbNone(default(T))` to make `none` option intent more clear.