### PR TITLE
Fix: length delimited records must only accept varint int32 length

### DIFF
--- a/protobuf_serialization/codec.nim
+++ b/protobuf_serialization/codec.nim
@@ -207,11 +207,8 @@ proc skipBytes(input: InputStream, n: int) {.raises: [SerializationError, IOErro
       raise (ref ProtobufValueError)(msg: "Not enough bytes")
     input.advance()
 
-proc readValue*[T: SomeVarint](input: InputStream, _: type T): T {.raises: [SerializationError, IOError].} =
-  # TODO This is not entirely correct: we should truncate value if it doesn't
-  #      fit, according to the docs:
-  #      https://developers.google.com/protocol-buffers/docs/proto#updating
-  var buf: Leb128Buf[uint64]
+proc readVarint[T: uint64 | uint32](input: InputStream, _: type T): T {.raises: [SerializationError, IOError].} =
+  var buf: Leb128Buf[T]
   while buf.len < buf.data.len and input.readable():
     let b = input.read()
     buf.data[buf.len] = b
@@ -219,10 +216,16 @@ proc readValue*[T: SomeVarint](input: InputStream, _: type T): T {.raises: [Seri
     if (b and 0x80'u8) == 0:
       break
 
-  let (val, len) = uint64.fromBytes(buf)
+  let (val, len) = T.fromBytes(buf)
   if buf.len == 0 or len != buf.len:
     raise (ref ProtobufValueError)(msg: "Cannot read varint from stream")
+  val
 
+proc readValue*[T: SomeVarint](input: InputStream, _: type T): T {.raises: [SerializationError, IOError].} =
+  # TODO This is not entirely correct: we should truncate value if it doesn't
+  #      fit, according to the docs:
+  #      https://developers.google.com/protocol-buffers/docs/proto#updating
+  let val = input.readVarint(uint64)
   fromUleb(val, T)
 
 proc skipValue*[T: SomeVarint](input: InputStream, _: type T) {.raises: [SerializationError, IOError].} =
@@ -243,11 +246,13 @@ proc skipValue*[T: SomeFixed32 | SomeFixed64](input: InputStream, _: type T) {.r
   static: doAssert sizeof(T) in {4, 8}
   input.skipBytes(sizeof(T))
 
+# https://protobuf.dev/programming-guides/encoding/#length-types
+# https://protobuf.dev/programming-guides/proto-limits/#total
 proc readLength*(input: InputStream): int {.raises: [SerializationError, IOError].} =
-  let lenu32 = input.readValue(puint32)
-  if uint64(lenu32) > uint64(int.high()):
+  let val = input.readVarint(uint32)
+  if val > uint32(int32.high()):
     raise (ref ProtobufValueError)(msg: "Invalid length")
-  int(lenu32)
+  int(val)
 
 proc readValue*[T: SomeLengthDelim](input: InputStream, _: type T): T {.raises: [SerializationError, IOError].} =
   let len = input.readLength()
@@ -255,7 +260,7 @@ proc readValue*[T: SomeLengthDelim](input: InputStream, _: type T): T {.raises: 
     type Base = typetraits.distinctBase(T)
     let inputLen = input.len()
     if inputLen.isSome() and len > inputLen.get():
-        raise (ref ProtobufValueError)(msg: "Missing bytes: " & $len)
+      raise (ref ProtobufValueError)(msg: "Missing bytes: " & $len)
 
     Base(result).setLen(len)
     template bytes(): openArray[byte] =

--- a/protobuf_serialization/files/proto_parser.nim
+++ b/protobuf_serialization/files/proto_parser.nim
@@ -1,4 +1,4 @@
-import npeg, strutils, sequtils, macros, os, options, sets
+import npeg, strutils, sequtils, macros, os, sets
 import decldef
 
 type
@@ -11,8 +11,8 @@ type
     index: int
     filePos: int
 
-proc `$`(t: Token): string =
-  $t.typ & ": " & t.text
+#proc `$`(t: Token): string =
+#  $t.typ & ": " & t.text
 
 proc `==`(t: Token, s: string): bool =
   result = t.typ == Ident and t.text == s

--- a/protobuf_serialization/reader.nim
+++ b/protobuf_serialization/reader.nim
@@ -40,6 +40,10 @@ proc readFieldInto[T: object and not Table](
     # stream.withReadableRange(len, inner):
     #   inner.readValueInternal(value)
 
+    let inputLen = stream.len()
+    if inputLen.isSome() and len > inputLen.get():
+      raise (ref ProtobufValueError)(msg: "Missing bytes: " & $len)
+
     var tmp = newSeqUninitialized[byte](len)
     if not stream.readInto(tmp):
       raise (ref ProtobufValueError)(msg: "not enough bytes")

--- a/tests/test_malformed.nim
+++ b/tests/test_malformed.nim
@@ -1,0 +1,116 @@
+import unittest2
+import stew/byteutils
+import ../protobuf_serialization
+
+type
+  Bytes {.proto3.} = object
+    x {.fieldNumber: 1.}: seq[byte]
+
+  Varint {.proto3.} = object
+    x {.fieldNumber: 1, pint.}: int64
+
+suite "Test well formed messages":
+  test "Bytes len 0":
+    # field 1, length-delimited, varint for 0
+    # echo "0A00" | xxd -r -p | protoc --decode=Bytes test_malformed.proto
+    let encoded = "0A00".hexToSeqByte
+    check ProtoBuf.decode(encoded, Bytes) == Bytes()
+
+  test "Bytes len 1":
+    # echo "0a0161" | xxd -r -p | protoc --decode=Bytes test_malformed.proto
+    # x: "a"
+    let encoded = "0a0161".hexToSeqByte
+    check ProtoBuf.decode(encoded, Bytes) == Bytes(x: @['a'.byte])
+
+  test "Length of 32-bit":
+    # echo "0A818080800061" | xxd -r -p | protoc --decode=Bytes test_malformed.proto
+    # x: "a"
+    let encoded = "0A818080800061".hexToSeqByte
+    check ProtoBuf.decode(encoded, Bytes) == Bytes(x: @['a'.byte])
+
+  test "Varint max int64":
+    let encoded = "08FFFFFFFFFFFFFFFF7F".hexToSeqByte
+    check ProtoBuf.decode(encoded, Varint) == Varint(x: int64.high)
+
+suite "Test malformed messages":
+  test "Max uint32 + 1 length":
+    # echo "0A8080808010" | xxd -r -p | protoc --decode=Bytes test_malformed.proto
+    # Failed to parse input.
+    # this must be rejected, not truncated; truncated == 0 (valid)
+    let encoded = "0A8080808010".hexToSeqByte
+    expect(ProtobufValueError):
+      discard ProtoBuf.decode(encoded, Bytes)
+
+  test "Max uint32 length":
+    # echo "0AFFFFFFFF0F" | xxd -r -p | protoc --decode=Bytes test_malformed.proto
+    # Failed to parse input.
+    let encoded = "0AFFFFFFFF0F".hexToSeqByte
+    # XXX should throw ProtobufLengthError; this could fail as "not enough bytes" to read
+    expect(ProtobufValueError):
+      discard ProtoBuf.decode(encoded, Bytes)
+
+  test "Max uint64 length":
+    let encoded = "0AFFFFFFFFFFFFFFFFFF01".hexToSeqByte
+    # XXX should throw ProtobufVarintError; this could fail as "not enough bytes" to read
+    expect(ProtobufValueError):
+      discard ProtoBuf.decode(encoded, Bytes)
+
+  test "Max int64 length":
+    # field 1, length-delimited, varint for int64.high
+    let encoded = "0AFFFFFFFFFFFFFFFF7F".hexToSeqByte
+    expect(ProtobufValueError):
+      discard ProtoBuf.decode(encoded, Bytes)
+ 
+  test "Length greater than bytes data":
+    let encoded = "0A054142".hexToSeqByte
+    expect(ProtobufValueError):
+      discard ProtoBuf.decode(encoded, Bytes)
+
+  test "Length 0 with trailing garbage":
+    let encoded = "0A00FFFF".hexToSeqByte
+    expect(ProtobufValueError):
+      discard ProtoBuf.decode(encoded, Bytes)
+
+  test "Truncated varint length":
+    let encoded = "0A8080808080".hexToSeqByte
+    expect(ProtobufValueError):
+      discard ProtoBuf.decode(encoded, Bytes)
+
+  test "Overlong varint encoding":
+    let encoded = "0A81808080808080808000".hexToSeqByte
+    expect(ProtobufValueError):
+      discard ProtoBuf.decode(encoded, Bytes)
+
+  test "Length of 64-bit":
+    # echo "0A8180808080808080800061" | xxd -r -p | protoc --decode=Bytes test_malformed.proto
+    # Failed to parse input.
+    let encoded = "0A8180808080808080800061".hexToSeqByte
+    expect(ProtobufValueError):
+      discard ProtoBuf.decode(encoded, Bytes)
+
+  test "Lenght of 64-bit variant":
+    let encoded = "08010AFFFFFFFFFFFFFFFF7F1002".hexToSeqByte
+    expect(ProtobufValueError):
+      discard ProtoBuf.decode(encoded, Bytes)
+
+  test "Length varint overflow":
+    # echo "0AFFFFFFFFFFFFFFFFFFFF01" | xxd -r -p | protoc --decode=Bytes test_malformed.proto
+    # Failed to parse input.
+    let encoded = "0AFFFFFFFFFFFFFFFFFFFF01".hexToSeqByte
+    expect(ProtobufValueError):
+      discard ProtoBuf.decode(encoded, Bytes)
+
+  test "Field key truncated":
+    let encoded = "80".hexToSeqByte
+    expect(ProtobufValueError):
+      discard ProtoBuf.decode(encoded, Bytes)
+
+  test "Invalid wire type 7":
+    let encoded = "0F".hexToSeqByte
+    expect(ProtobufValueError):
+      discard ProtoBuf.decode(encoded, Bytes)
+
+  test "Varint greater than max uint64":
+    let encoded = "08FFFFFFFFFFFFFFFFFFFF01".hexToSeqByte
+    expect(ProtobufValueError):
+      discard ProtoBuf.decode(encoded, Varint)

--- a/tests/test_malformed.proto
+++ b/tests/test_malformed.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+message Bytes {
+  bytes x = 1;
+}
+
+message Varint {
+  int64 x = 1;
+}


### PR DESCRIPTION
Changes:

- Fix length delimited records; read varint32 instead of int64 + truncate
- Verify length does not exceed data len
- Add malformed data tests