### PR TITLE
import_proto3: Generate `seq[Entry]` for map type

### DIFF
--- a/protobuf_serialization/files/type_generator.nim
+++ b/protobuf_serialization/files/type_generator.nim
@@ -78,20 +78,28 @@ proc getMessage(name: string, messages: seq[ProtoNode]): ProtoNode =
       return res
   return nil
 
-proc isNested(base: string, currentName: string, messages: seq[ProtoNode]): bool =
+proc isNested(base: string, currentName: string, messages: seq[ProtoNode], seen: var seq[ProtoNode]): bool =
   let msg = currentName.getMessage(messages)
   if msg.isNil():
     return false
+  if msg in seen:
+    return false
+  seen.add msg
   for field in msg.fields:
     if field.kind == ProtoType.Field:
       if field.presence == Repeated: continue
-      if base == field.protoType or base.isNested(field.protoType, messages):
+      if base == field.protoType or base.isNested(field.protoType, messages, seen):
         return true
     elif field.kind == ProtoType.Oneof:
       for f in field.oneof:
         if f.presence == Repeated: continue
-        if base == f.protoType or base.isNested(f.protoType, messages):
+        if base == f.protoType or base.isNested(f.protoType, messages, seen):
           return true
+
+proc isNested(base: string, currentName: string, messages: seq[ProtoNode]): bool =
+  # XXX use a set
+  var seen = default(seq[ProtoNode])
+  isNested(base, currentName, messages, seen)
 
 # Exported for the tests.
 proc protoToTypesInternal*(filepath: string, isProto3 = true): NimNode {.compileTime.} =
@@ -102,6 +110,21 @@ proc protoToTypesInternal*(filepath: string, isProto3 = true): NimNode {.compile
   for parsed in packages:
     for msg in parsed.messages:
       queue.add(msg)
+      if msg.kind != ProtoType.Extend:
+        for field in msg.fields:
+          if field.kind == ProtoType.Oneof:
+            # XXX this should be supported
+            continue
+          if field.protoType.startsWith("map<"):
+            let matches = field.protoType.split({'<', '>', ','})
+            let entryFields = @[
+              ProtoNode(kind: Field, number: 1, protoType: matches[1], name: "key"),
+              ProtoNode(kind: Field, number: 2, protoType: matches[2], name: "value")
+            ]
+            queue.add ProtoNode(
+              kind: Message,
+              messageName: field.name & "Entry",
+              fields: entryFields)
       # TODO: define Enums first to workaround https://github.com/nim-lang/Nim/issues/25651
       if msg.kind != ProtoType.Extend:
         if (msg.definedEnums.len != 0) or (msg.nested.len != 0):
@@ -176,10 +199,9 @@ proc protoToTypesInternal*(filepath: string, isProto3 = true): NimNode {.compile
               break
 
           if value[2][^1][1].strVal.startsWith("map<"):
-            var matches = value[2][^1][1].strVal.split({'<', '>', ','})
-            let (typ1, _) = getTypeAndPragma(matches[1])
-            let (typ2, _) = getTypeAndPragma(matches[2])
-            value[2][^1][1] = nnkBracketExpr.newTree(newIdentNode("Table"), typ1, typ2)
+            value[2][^1][1] = newNimNode(nnkBracketExpr).add(
+              ident("seq"), ident(field.name & "Entry")
+            )
           else:
             let (typ, pragma) = getTypeAndPragma(value[2][^1][1].strVal)
             value[2][^1][1] = typ

--- a/protobuf_serialization/internal.nim
+++ b/protobuf_serialization/internal.nim
@@ -2,7 +2,7 @@
 
 {.push raises: [], gcsafe.}
 
-import std/[options, sets, tables]
+import std/[options, sets]
 import stew/shims/macros
 #Depending on the situation, one of these two are used.
 #Sometimes, one works where the other doesn't.
@@ -55,28 +55,6 @@ proc fieldNumberOf*(T: type, fieldName: static string): int {.compileTime.} =
     fieldError T, fieldName, "Missing {.fieldNumber: N.}"
   else:
     fieldNum
-
-template tableObject*(TableObject, K, V) =
-  when K is SomePBInt and V is SomePBInt:
-    type
-      TableObject {.proto3.} = object
-        key {.fieldNumber: 1, pint.}: K
-        value {.fieldNumber: 2, pint.}: V
-  elif K is SomePBInt:
-    type
-      TableObject {.proto3.} = object
-        key {.fieldNumber: 1, pint.}: K
-        value {.fieldNumber: 2.}: V
-  elif V is SomePBInt:
-    type
-      TableObject {.proto3.} = object
-        key {.fieldNumber: 1.}: K
-        value {.fieldNumber: 2, pint.}: V
-  else:
-    type
-      TableObject {.proto3.} = object
-        key {.fieldNumber: 1.}: K
-        value {.fieldNumber: 2.}: V
 
 template protoType*(InnerType, RootType, FieldType: untyped, fieldName: untyped) =
   mixin flatType
@@ -149,8 +127,6 @@ template protoType*(InnerType, RootType, FieldType: untyped, fieldName: untyped)
     type InnerType = UnsupportedType[FieldType, RootType, fieldName]
 
 template elementType[T](_: type seq[T]): type = typeof(T)
-template elementTypeKey[K, V](_: type Table[K, V]): type = typeof(K)
-template elementTypeVal[K, V](_: type Table[K, V]): type = typeof(V)
 
 func verifySerializable*[T](ty: typedesc[T]) {.compileTime.} =
   type FlatType = flatType(default(T))
@@ -164,12 +140,6 @@ func verifySerializable*[T](ty: typedesc[T]) {.compileTime.} =
         # type Value = object (list: List)
       else:
         verifySerializable(elementType(FlatType))
-  elif FlatType is Table and defined(ConformanceTest):
-    return # TODO make it work in case of recursivity
-    # type Struct = object (map: Table[..., Value])
-    # type Value = object (struct: Struct)
-    # verifySerializable(elementTypeKey(FlatType))
-    # verifySerializable(elementTypeVal(FlatType))
   elif FlatType is object and T isnot PBOption:
     var
       inst: T
@@ -183,7 +153,7 @@ func verifySerializable*[T](ty: typedesc[T]) {.compileTime.} =
 
     enumInstanceSerializedFields(inst, fieldName, fieldVar):
       when isProto2 and not T.isRequired(fieldName):
-        when fieldVar is not (seq or PBOption or Table):
+        when fieldVar is not (seq or PBOption):
           fieldError T, fieldName, "proto2 requires every field to either have the required pragma attached or be a repeated field/PBOption."
       when isProto3 and (
         T.hasCustomPragmaFixed(fieldName, required) or

--- a/protobuf_serialization/reader.nim
+++ b/protobuf_serialization/reader.nim
@@ -3,7 +3,7 @@
 {.push raises: [], gcsafe.}
 
 import
-  std/[typetraits, sets, tables],
+  std/[typetraits, sets],
   stew/assign2,
   stew/objects,
   stew/shims/macros,
@@ -18,7 +18,7 @@ proc readValueInternal[T: object](stream: InputStream, value: var T, silent: boo
 macro unsupported(T: typed): untyped =
   error "Assignment of the type " & humaneTypeName(T) & " is not supported"
 
-proc readFieldInto[T: object and not Table](
+proc readFieldInto[T: object](
   stream: InputStream,
   value: var T,
   header: FieldHeader,
@@ -56,17 +56,6 @@ when defined(ConformanceTest):
     let enumValue = stream.readValue(ProtoType)
     if not checkedEnumAssign(value, enumValue.int32):
       discard checkedEnumAssign(value, 0)
-
-  proc readFieldInto[K, V](
-    stream: InputStream,
-    value: var Table[K, V],
-    header: FieldHeader,
-    ProtoType: type
-  ) {.raises: [SerializationError, IOError].} =
-    tableObject(TableObject, K, V)
-    var tmp = default(TableObject)
-    stream.readFieldInto(tmp, header, ProtoType)
-    value[tmp.key] = tmp.value
 
 proc readFieldInto[T: not object and not enum and (seq[byte] or not seq)](
   stream: InputStream,

--- a/protobuf_serialization/sizer.nim
+++ b/protobuf_serialization/sizer.nim
@@ -1,7 +1,7 @@
 {.push raises: [], gcsafe.}
 
 import
-  std/[typetraits, tables],
+  std/[typetraits],
   stew/shims/macros,
   serialization,
   "."/[codec, internal, types]
@@ -60,14 +60,6 @@ when defined(ConformanceTest):
     when 0 notin T:
       {.fatal: $T & " definition must contain a constant that maps to zero".}
     stream.writeField(fieldNum, pint32(fieldVal.ord()))
-
-  proc computeFieldSize*[K, V](
-      fieldNum: int, fieldVal: Table[K, V], ProtoType: type pbytes,
-      skipDefault: static bool): int =
-    tableObject(TableObject, K, V)
-    for k, v in fieldVal.pairs():
-      let tmp = TableObject(key: k, value: v)
-      result += computeFieldSize(fieldNum, tmp, ProtoType, false)
 
 proc computeSizePacked*[T: not byte, ProtoType: SomePrimitive](
     values: openArray[T], _: type ProtoType): int =

--- a/protobuf_serialization/writer.nim
+++ b/protobuf_serialization/writer.nim
@@ -3,7 +3,7 @@
 {.push raises: [], gcsafe.}
 
 import
-  std/[typetraits, tables],
+  std/[typetraits],
   stew/shims/macros,
   stew/objects,
   faststreams/outputs,
@@ -20,7 +20,7 @@ proc writeField*(
   # TODO turn this into an extension point
   unsupportedProtoType ProtoType.FieldType, ProtoType.RootType, ProtoType.fieldName
 
-proc writeField*[T: object and not PBOption and not Table](
+proc writeField*[T: object and not PBOption](
     stream: OutputStream, fieldNum: int, fieldVal: T, ProtoType: type pbytes,
     skipDefault: static bool = false) {.raises: [IOError].} =
   let
@@ -83,18 +83,6 @@ when defined(ConformanceTest):
       if fieldVal.ord() == 0:
         return
     stream.writeField(fieldNum, pint32(fieldVal.ord()))
-
-  proc writeField[K, V](
-    stream: OutputStream,
-    fieldNum: int,
-    value: Table[K, V],
-    ProtoType: type,
-    skipDefault: static bool = false
-  ) {.raises: [IOError].} =
-    tableObject(TableObject, K, V)
-    for k, v in value.pairs():
-      let tmp = TableObject(key: k, value: v)
-      stream.writeField(fieldNum, tmp, ProtoType)
 
 proc writeField*(
     stream: OutputStream, fieldNum: int, fieldVal: PBOption, ProtoType: type,

--- a/tests/conformance/failure_list.txt
+++ b/tests/conformance/failure_list.txt
@@ -1,81 +1,41 @@
-Required.Proto2.ProtobufInput.PrematureEofInSubmessageValue.MESSAGE
-Required.Proto2.ProtobufInput.RepeatedScalarMessageMerge.ProtobufOutput
-Required.Proto2.ProtobufInput.UnknownOrdering.ProtobufOutput
-Required.Proto2.ProtobufInput.UnknownVarint.ProtobufOutput
-Required.Proto2.ProtobufInput.UnmatchedEndGroupNestedLen
-Required.Proto2.ProtobufInput.UnmatchedStartGroupNestedLen
-Required.Proto2.ProtobufInput.ValidDataMap.FIXED32.FIXED32.DuplicateKey.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataMap.FIXED32.FIXED32.DuplicateKeyInMapEntry.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataMap.FIXED32.FIXED32.DuplicateValueInMapEntry.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataMap.FIXED32.FIXED32.NonDefault.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataMap.FIXED32.FIXED32.Unordered.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataMap.FIXED64.FIXED64.DuplicateKey.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataMap.FIXED64.FIXED64.DuplicateKeyInMapEntry.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataMap.FIXED64.FIXED64.DuplicateValueInMapEntry.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataMap.FIXED64.FIXED64.NonDefault.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataMap.FIXED64.FIXED64.Unordered.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataMap.SFIXED32.SFIXED32.DuplicateKey.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataMap.SFIXED32.SFIXED32.DuplicateKeyInMapEntry.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataMap.SFIXED32.SFIXED32.DuplicateValueInMapEntry.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataMap.SFIXED32.SFIXED32.NonDefault.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataMap.SFIXED32.SFIXED32.Unordered.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataMap.SFIXED64.SFIXED64.DuplicateKey.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataMap.SFIXED64.SFIXED64.DuplicateKeyInMapEntry.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataMap.SFIXED64.SFIXED64.DuplicateValueInMapEntry.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataMap.SFIXED64.SFIXED64.NonDefault.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataMap.SFIXED64.SFIXED64.Unordered.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataMap.STRING.MESSAGE.Default.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataMap.STRING.MESSAGE.DuplicateKey.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataMap.STRING.MESSAGE.DuplicateKeyInMapEntry.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataMap.STRING.MESSAGE.DuplicateValueInMapEntry.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataMap.STRING.MESSAGE.MergeValue.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataMap.STRING.MESSAGE.MissingDefault.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataMap.STRING.MESSAGE.NonDefault.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataMap.STRING.MESSAGE.Unordered.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataOneof.BOOL.MultipleValuesForDifferentField.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataOneof.BYTES.MultipleValuesForDifferentField.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataOneof.DOUBLE.MultipleValuesForDifferentField.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataOneof.ENUM.MultipleValuesForDifferentField.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataOneof.FLOAT.MultipleValuesForDifferentField.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataOneof.MESSAGE.DefaultValue.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataOneof.MESSAGE.Merge.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataOneof.MESSAGE.MultipleValuesForDifferentField.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataOneof.MESSAGE.MultipleValuesForSameField.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataOneof.MESSAGE.NonDefaultValue.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataOneof.STRING.MultipleValuesForDifferentField.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataOneof.UINT64.MultipleValuesForDifferentField.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataRepeated.MESSAGE.ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataScalar.MESSAGE[0].ProtobufOutput
-Required.Proto2.ProtobufInput.ValidDataScalar.MESSAGE[1].ProtobufOutput
-Required.Proto3.ProtobufInput.RepeatedScalarMessageMerge.ProtobufOutput
-Required.Proto3.ProtobufInput.UnknownOrdering.ProtobufOutput
-Required.Proto3.ProtobufInput.UnknownVarint.ProtobufOutput
-Required.Proto3.ProtobufInput.ValidDataMap.FIXED32.FIXED32.DuplicateKey.ProtobufOutput
-Required.Proto3.ProtobufInput.ValidDataMap.FIXED32.FIXED32.DuplicateKeyInMapEntry.ProtobufOutput
-Required.Proto3.ProtobufInput.ValidDataMap.FIXED32.FIXED32.DuplicateValueInMapEntry.ProtobufOutput
-Required.Proto3.ProtobufInput.ValidDataMap.FIXED32.FIXED32.NonDefault.ProtobufOutput
-Required.Proto3.ProtobufInput.ValidDataMap.FIXED32.FIXED32.Unordered.ProtobufOutput
-Required.Proto3.ProtobufInput.ValidDataMap.FIXED64.FIXED64.DuplicateKey.ProtobufOutput
-Required.Proto3.ProtobufInput.ValidDataMap.FIXED64.FIXED64.DuplicateKeyInMapEntry.ProtobufOutput
-Required.Proto3.ProtobufInput.ValidDataMap.FIXED64.FIXED64.DuplicateValueInMapEntry.ProtobufOutput
-Required.Proto3.ProtobufInput.ValidDataMap.FIXED64.FIXED64.NonDefault.ProtobufOutput
-Required.Proto3.ProtobufInput.ValidDataMap.FIXED64.FIXED64.Unordered.ProtobufOutput
-Required.Proto3.ProtobufInput.ValidDataMap.SFIXED32.SFIXED32.DuplicateKey.ProtobufOutput
-Required.Proto3.ProtobufInput.ValidDataMap.SFIXED32.SFIXED32.DuplicateKeyInMapEntry.ProtobufOutput
-Required.Proto3.ProtobufInput.ValidDataMap.SFIXED32.SFIXED32.DuplicateValueInMapEntry.ProtobufOutput
-Required.Proto3.ProtobufInput.ValidDataMap.SFIXED32.SFIXED32.NonDefault.ProtobufOutput
-Required.Proto3.ProtobufInput.ValidDataMap.SFIXED32.SFIXED32.Unordered.ProtobufOutput
-Required.Proto3.ProtobufInput.ValidDataMap.SFIXED64.SFIXED64.DuplicateKey.ProtobufOutput
-Required.Proto3.ProtobufInput.ValidDataMap.SFIXED64.SFIXED64.DuplicateKeyInMapEntry.ProtobufOutput
-Required.Proto3.ProtobufInput.ValidDataMap.SFIXED64.SFIXED64.DuplicateValueInMapEntry.ProtobufOutput
-Required.Proto3.ProtobufInput.ValidDataMap.SFIXED64.SFIXED64.NonDefault.ProtobufOutput
-Required.Proto3.ProtobufInput.ValidDataMap.SFIXED64.SFIXED64.Unordered.ProtobufOutput
-Required.Proto3.ProtobufInput.ValidDataOneof.BOOL.DefaultValue.ProtobufOutput
-Required.Proto3.ProtobufInput.ValidDataOneof.BYTES.DefaultValue.ProtobufOutput
-Required.Proto3.ProtobufInput.ValidDataOneof.DOUBLE.DefaultValue.ProtobufOutput
-Required.Proto3.ProtobufInput.ValidDataOneof.ENUM.DefaultValue.ProtobufOutput
-Required.Proto3.ProtobufInput.ValidDataOneof.FLOAT.DefaultValue.ProtobufOutput
-Required.Proto3.ProtobufInput.ValidDataOneof.MESSAGE.Merge.ProtobufOutput
-Required.Proto3.ProtobufInput.ValidDataOneof.STRING.DefaultValue.ProtobufOutput
-Required.Proto3.ProtobufInput.ValidDataOneof.UINT32.DefaultValue.ProtobufOutput
-Required.Proto3.ProtobufInput.ValidDataOneof.UINT64.DefaultValue.ProtobufOutput
+Required.Proto2.ProtobufInput.PrematureEofInSubmessageValue.MESSAGE # Should have failed to parse, but didn't.
+Required.Proto2.ProtobufInput.RepeatedScalarMessageMerge.ProtobufOutput # Output was not equivalent to reference message: deleted: optional_nested_message: { corecursive { optional_int32: 4321 optional_
+Required.Proto2.ProtobufInput.UnknownOrdering.ProtobufOutput # Unknown field mismatch
+Required.Proto2.ProtobufInput.UnknownVarint.ProtobufOutput # Output was not equivalent to reference message: Expect: \250\037\001, but got: 
+Required.Proto2.ProtobufInput.UnmatchedEndGroupNestedLen # Should have failed to parse, but didn't.
+Required.Proto2.ProtobufInput.UnmatchedStartGroupNestedLen # Should have failed to parse, but didn't.
+Required.Proto2.ProtobufInput.ValidDataMap.STRING.MESSAGE.Default.ProtobufOutput # Output was not equivalent to reference message: deleted: map_string_nested_message['']: { }
+Required.Proto2.ProtobufInput.ValidDataMap.STRING.MESSAGE.DuplicateKey.ProtobufOutput # Output was not equivalent to reference message: deleted: map_string_nested_message[a]: { a: 1234 }
+Required.Proto2.ProtobufInput.ValidDataMap.STRING.MESSAGE.DuplicateKeyInMapEntry.ProtobufOutput # Output was not equivalent to reference message: deleted: map_string_nested_message[a]: { a: 1234 }
+Required.Proto2.ProtobufInput.ValidDataMap.STRING.MESSAGE.DuplicateValueInMapEntry.ProtobufOutput # Output was not equivalent to reference message: deleted: map_string_nested_message[a]: { a: 1234 }
+Required.Proto2.ProtobufInput.ValidDataMap.STRING.MESSAGE.MergeValue.ProtobufOutput # Output was not equivalent to reference message: deleted: map_string_nested_message['']: { corecursive { optional_int64: 1 repeat
+Required.Proto2.ProtobufInput.ValidDataMap.STRING.MESSAGE.MissingDefault.ProtobufOutput # Output was not equivalent to reference message: deleted: map_string_nested_message['']: { }
+Required.Proto2.ProtobufInput.ValidDataMap.STRING.MESSAGE.NonDefault.ProtobufOutput # Output was not equivalent to reference message: deleted: map_string_nested_message[a]: { a: 1234 }
+Required.Proto2.ProtobufInput.ValidDataMap.STRING.MESSAGE.Unordered.ProtobufOutput # Output was not equivalent to reference message: deleted: map_string_nested_message[a]: { a: 1234 }
+Required.Proto2.ProtobufInput.ValidDataOneof.BOOL.MultipleValuesForDifferentField.ProtobufOutput # Output was not equivalent to reference message: added: oneof_uint32: 0deleted: oneof_bool: true
+Required.Proto2.ProtobufInput.ValidDataOneof.BYTES.MultipleValuesForDifferentField.ProtobufOutput # Output was not equivalent to reference message: added: oneof_uint32: 0deleted: oneof_bytes: "a"
+Required.Proto2.ProtobufInput.ValidDataOneof.DOUBLE.MultipleValuesForDifferentField.ProtobufOutput # Output was not equivalent to reference message: added: oneof_uint32: 0deleted: oneof_double: 1
+Required.Proto2.ProtobufInput.ValidDataOneof.ENUM.MultipleValuesForDifferentField.ProtobufOutput # Output was not equivalent to reference message: added: oneof_uint32: 0deleted: oneof_enum: BAR
+Required.Proto2.ProtobufInput.ValidDataOneof.FLOAT.MultipleValuesForDifferentField.ProtobufOutput # Output was not equivalent to reference message: added: oneof_uint32: 0deleted: oneof_float: 1
+Required.Proto2.ProtobufInput.ValidDataOneof.MESSAGE.DefaultValue.ProtobufOutput # Output was not equivalent to reference message: deleted: oneof_nested_message: { }
+Required.Proto2.ProtobufInput.ValidDataOneof.MESSAGE.Merge.ProtobufOutput # Output was not equivalent to reference message: deleted: oneof_nested_message: { corecursive { optional_int32: 1 optional_int64:
+Required.Proto2.ProtobufInput.ValidDataOneof.MESSAGE.MultipleValuesForDifferentField.ProtobufOutput # Output was not equivalent to reference message: added: oneof_uint32: 0deleted: oneof_nested_message: { a: 1234 }
+Required.Proto2.ProtobufInput.ValidDataOneof.MESSAGE.MultipleValuesForSameField.ProtobufOutput # Output was not equivalent to reference message: deleted: oneof_nested_message: { a: 1234 }
+Required.Proto2.ProtobufInput.ValidDataOneof.MESSAGE.NonDefaultValue.ProtobufOutput # Output was not equivalent to reference message: deleted: oneof_nested_message: { a: 1234 }
+Required.Proto2.ProtobufInput.ValidDataOneof.STRING.MultipleValuesForDifferentField.ProtobufOutput # Output was not equivalent to reference message: added: oneof_uint32: 0deleted: oneof_string: "a"
+Required.Proto2.ProtobufInput.ValidDataOneof.UINT64.MultipleValuesForDifferentField.ProtobufOutput # Output was not equivalent to reference message: added: oneof_uint32: 0deleted: oneof_uint64: 1
+Required.Proto2.ProtobufInput.ValidDataRepeated.MESSAGE.ProtobufOutput # Output was not equivalent to reference message: deleted: repeated_nested_message[0]: { }deleted: repeated_nested_message[1]: { a
+Required.Proto2.ProtobufInput.ValidDataScalar.MESSAGE[0].ProtobufOutput # Output was not equivalent to reference message: deleted: optional_nested_message: { }
+Required.Proto2.ProtobufInput.ValidDataScalar.MESSAGE[1].ProtobufOutput # Output was not equivalent to reference message: deleted: optional_nested_message: { a: 1234 }
+Required.Proto3.ProtobufInput.RepeatedScalarMessageMerge.ProtobufOutput # Output was not equivalent to reference message: deleted: optional_nested_message.corecursive.optional_int64: 1234modified: optio
+Required.Proto3.ProtobufInput.UnknownOrdering.ProtobufOutput # Unknown field mismatch
+Required.Proto3.ProtobufInput.UnknownVarint.ProtobufOutput # Output was not equivalent to reference message: Expect: \250\037\001, but got: 
+Required.Proto3.ProtobufInput.ValidDataOneof.BOOL.DefaultValue.ProtobufOutput # Output was not equivalent to reference message: deleted: oneof_bool: false
+Required.Proto3.ProtobufInput.ValidDataOneof.BYTES.DefaultValue.ProtobufOutput # Output was not equivalent to reference message: deleted: oneof_bytes: ""
+Required.Proto3.ProtobufInput.ValidDataOneof.DOUBLE.DefaultValue.ProtobufOutput # Output was not equivalent to reference message: deleted: oneof_double: 0
+Required.Proto3.ProtobufInput.ValidDataOneof.ENUM.DefaultValue.ProtobufOutput # Output was not equivalent to reference message: deleted: oneof_enum: FOO
+Required.Proto3.ProtobufInput.ValidDataOneof.FLOAT.DefaultValue.ProtobufOutput # Output was not equivalent to reference message: deleted: oneof_float: 0
+Required.Proto3.ProtobufInput.ValidDataOneof.MESSAGE.Merge.ProtobufOutput # Output was not equivalent to reference message: deleted: oneof_nested_message.corecursive.optional_int32: 1deleted: oneof_nested
+Required.Proto3.ProtobufInput.ValidDataOneof.STRING.DefaultValue.ProtobufOutput # Output was not equivalent to reference message: deleted: oneof_string: ""
+Required.Proto3.ProtobufInput.ValidDataOneof.UINT32.DefaultValue.ProtobufOutput # Output was not equivalent to reference message: deleted: oneof_uint32: 0
+Required.Proto3.ProtobufInput.ValidDataOneof.UINT64.DefaultValue.ProtobufOutput # Output was not equivalent to reference message: deleted: oneof_uint64: 0


### PR DESCRIPTION
Current Table implementation is not conformant; it may hide bugs (#67). To make it conformant needs to support duplicate keys, and add a way to specify its key/value proto type in the pragma. Likely implemented as an extension `/protobuf_serialization/pkg/tables`.

Changes:

- import_proto3: Generate `seq[Entry]` for map type instead of `Table[K, V]`

HEAD:

```
CONFORMANCE SUITE PASSED: 1275 successes, 1367 skipped, 81 expected failures, 0 unexpected failures.
```

This PR:

```
CONFORMANCE SUITE PASSED: 1315 successes, 1367 skipped, 41 expected failures, 0 unexpected failures.
```