### PR TITLE
Implement `Oneof` field

### DIFF
--- a/protobuf_serialization/files/proto_parser.nim
+++ b/protobuf_serialization/files/proto_parser.nim
@@ -134,7 +134,9 @@ proc parseProtoPackage(file: string, toImport: var HashSet[string]): ProtoNode =
           kind: Field,
           number: parseInt(fieldValue),
           protoType: fieldType,
-          name: fieldName)))
+          name: fieldName,
+          options: ps.fieldOpts)))
+      ps.fieldOpts.setLen 0
     oneof2     <- ["oneof"] * >ident * ['{'] * *(option | oneoffield) * ['}']:
       ps.fields.add(($0, ProtoNode(
         oneofName: ($1).text,

--- a/protobuf_serialization/files/type_generator.nim
+++ b/protobuf_serialization/files/type_generator.nim
@@ -121,13 +121,23 @@ proc protoToTypesInternal*(filepath: string, isProto3 = true): NimNode {.compile
       if msg.kind != ProtoType.Extend:
         for field in msg.fields:
           if field.kind == ProtoType.Oneof:
-            # XXX this should be supported
-            continue
-          if field.protoType.startsWith("map<"):
+            # Oneof does not allow: map, repeated, optional
+            queue.add(field)
+            # Add oneof case field enum
+            var enumVals = @[ProtoNode(kind: ProtoType.EnumVal, fieldName: "unset", num: 0)]
+            for i, f in field.oneof.pairs():
+              doAssert f.kind == ProtoType.Field, $f.kind
+              enumVals.add ProtoNode(kind: ProtoType.EnumVal, fieldName: f.name, num: i + 1)
+            queue.add ProtoNode(
+              kind: ProtoType.Enum,
+              enumName: field.oneofName.capitalizeAscii() & "Kind",
+              values: enumVals
+            )
+          elif field.kind == ProtoType.Field and field.protoType.startsWith("map<"):
             let matches = field.protoType.split({'<', '>', ','})
             let entryFields = @[
-              ProtoNode(kind: Field, number: 1, protoType: matches[1], name: "key"),
-              ProtoNode(kind: Field, number: 2, protoType: matches[2], name: "value")
+              ProtoNode(kind: ProtoType.Field, number: 1, protoType: matches[1], name: "key"),
+              ProtoNode(kind: ProtoType.Field, number: 2, protoType: matches[2], name: "value")
             ]
             queue.add ProtoNode(
               kind: Message,
@@ -135,9 +145,10 @@ proc protoToTypesInternal*(filepath: string, isProto3 = true): NimNode {.compile
               fields: entryFields)
       # TODO: define Enums first to workaround https://github.com/nim-lang/Nim/issues/25651
       if msg.kind != ProtoType.Extend:
-        if (msg.definedEnums.len != 0) or (msg.nested.len != 0):
-          for nestee in (msg.definedEnums & msg.nested):
-            queue.add(nestee)
+        for pbEnum in msg.definedEnums:
+          queue.add(pbEnum)
+        for nestee in msg.nested:
+          queue.add(nestee)
     for pbEnum in parsed.packageEnums:
       queue.add(pbEnum)
 
@@ -159,6 +170,46 @@ proc protoToTypesInternal*(filepath: string, isProto3 = true): NimNode {.compile
             ident(enumField.fieldName),
             newIntLitNode(enumField.num)
           ))
+      elif next.kind == ProtoType.Oneof:
+        name = next.oneofName.capitalizeAscii()
+        let caseKind = ident(name & "Kind")
+        let caseOf = newNimNode(nnkRecCase).add(
+          newIdentDefs(newNimNode(nnkPostfix).add(ident("*"), ident("kind")), caseKind),
+          newNimNode(nnkOfBranch).add(
+            newDotExpr(caseKind, ident"unset"),
+            newNimNode(nnkRecList).add(newNilLit())
+          )
+        )
+        for field in next.oneof:
+          doAssert field.kind == ProtoType.Field, $field.kind
+          let (typ, pragma) = if field.protoType == "google.protobuf.Any":
+            getTypeAndPragma("bytes")
+          else:
+            getTypeAndPragma(field.protoType)
+          var pragmas = default(seq[NimNode])
+          if not pragma.isNil():
+            pragmas.add pragma
+          if field.protoType.split('.')[^1] in enumNames:
+            pragmas.add ident"ext"
+          caseOf.add(
+            newNimNode(nnkOfBranch).add(
+              newDotExpr(caseKind, ident(field.name)),
+              newNimNode(nnkRecList).add(newIdentDefs(
+                newNimNode(nnkPragmaExpr).add(
+                  newNimNode(nnkPostfix).add(ident("*"), ident(field.name)),
+                  newNimNode(nnkPragma).add(
+                    newNimNode(nnkExprColonExpr).add(ident("fieldNumber"), newIntLitNode(field.number))
+                  ).add(pragmas)
+                ),
+                typ
+              ))
+            )
+          )
+        value = newNimNode(nnkObjectTy).add(
+          newEmptyNode(),
+          newEmptyNode(),
+          newNimNode(nnkRecList).add(caseOf)
+        )
       else:
         if next.kind == ProtoType.Extend:
           continue
@@ -172,82 +223,91 @@ proc protoToTypesInternal*(filepath: string, isProto3 = true): NimNode {.compile
           newEmptyNode(),
           newNimNode(nnkRecList)
         )
-        var fieldsQueue: seq[ProtoNode] = @[]
         for field in next.fields:
-          fieldsQueue.add(field)
-        while fieldsQueue.len != 0:
-          let field = fieldsQueue.pop()
-          if field.kind == Oneof:
-            # TODO: ATM the oneof is ignored. Find a way to make it work
-            for f in field.oneof:
-              f.presence = Optional
-              fieldsQueue.add(f)
-            continue
-          value[2].add(newNimNode(nnkIdentDefs).add(
-            newNimNode(nnkPragmaExpr).add(
-              newNimNode(nnkPostfix).add(
-                ident("*"),
-                ident(field.name)
+          case field.kind
+          of ProtoType.Oneof:
+            value[2].add(newNimNode(nnkIdentDefs).add(
+              newNimNode(nnkPragmaExpr).add(
+                newNimNode(nnkPostfix).add(
+                  ident("*"),
+                  ident(field.oneofName)
+                ),
+                newNimNode(nnkPragma).add(ident("oneof"))
               ),
-              newNimNode(nnkPragma).add(
-                newNimNode(nnkExprColonExpr).add(
-                  ident("fieldNumber"),
-                  newIntLitNode(field.number)
+              # XXX namespace
+              ident(field.oneofName.capitalizeAscii()),
+              newEmptyNode()
+            ))
+          of ProtoType.Field:
+            value[2].add(newNimNode(nnkIdentDefs).add(
+              newNimNode(nnkPragmaExpr).add(
+                newNimNode(nnkPostfix).add(
+                  ident("*"),
+                  ident(field.name)
+                ),
+                newNimNode(nnkPragma).add(
+                  newNimNode(nnkExprColonExpr).add(
+                    ident("fieldNumber"),
+                    newIntLitNode(field.number)
+                  )
                 )
+              ),
+              ident(if field.protoType == "google.protobuf.Any": "bytes" else: field.protoType),
+              newEmptyNode()
+            ))
+
+            var isReference = false
+            for parsed in packages:
+              if next.messageName.isNested(field.protoType, parsed.messages):
+                isReference = true
+                break
+
+            if value[2][^1][1].strVal.startsWith("map<"):
+              value[2][^1][1] = newNimNode(nnkBracketExpr).add(
+                ident("seq"), ident(field.name & "Entry")
               )
-            ),
-            ident(if field.protoType == "google.protobuf.Any": "bytes" else: field.protoType),
-            newEmptyNode()
-          ))
-
-          var isReference = false
-          for parsed in packages:
-            if next.messageName.isNested(field.protoType, parsed.messages):
-              isReference = true
-              break
-
-          if value[2][^1][1].strVal.startsWith("map<"):
-            value[2][^1][1] = newNimNode(nnkBracketExpr).add(
-              ident("seq"), ident(field.name & "Entry")
-            )
-          else:
-            let (typ, pragma) = getTypeAndPragma(value[2][^1][1].strVal)
-            value[2][^1][1] = typ
-            if not pragma.isNil():
-              value[2][^1][0][1].add(pragma)
-
-          # XXX fix namespaces
-          if field.protoType.split('.')[^1] in enumNames:
-            value[2][^1][0][1].add ident"ext"
-
-          if field.presence == Optional and not isProto3:
-            var optDefault = ""
-            for opt in field.options:
-              if opt.optName == "default":
-                optDefault = opt.optVal
-            let typ = value[2][^1][1]
-            let innerTyp = if optDefault.len > 0:
-              parseDefault(optDefault, typ)
             else:
-              quote do: default(`typ`)
-            value[2][^1][1] = quote do: PBOption[`innerTyp`]
+              let (typ, pragma) = getTypeAndPragma(value[2][^1][1].strVal)
+              value[2][^1][1] = typ
+              if not pragma.isNil():
+                value[2][^1][0][1].add(pragma)
 
-          for opt in field.options:
-            if opt.optName == "packed" and opt.optVal in ["true", "false"]:
-              value[2][^1][0][1].add(
-                newNimNode(nnkExprColonExpr).add(
-                  ident(opt.optName),
-                  newLitFixed(opt.optVal == "true")
+            # XXX fix namespaces
+            if field.protoType.split('.')[^1] in enumNames:
+              value[2][^1][0][1].add ident"ext"
+
+            if field.presence == Optional and not isProto3:
+              var optDefault = ""
+              for opt in field.options:
+                if opt.optName == "default":
+                  optDefault = opt.optVal
+              let typ = value[2][^1][1]
+              let innerTyp = if optDefault.len > 0:
+                parseDefault(optDefault, typ)
+              else:
+                quote do: default(`typ`)
+              value[2][^1][1] = quote do: PBOption[`innerTyp`]
+
+            for opt in field.options:
+              if opt.optName == "packed" and opt.optVal in ["true", "false"]:
+                value[2][^1][0][1].add(
+                  newNimNode(nnkExprColonExpr).add(
+                    ident(opt.optName),
+                    newLitFixed(opt.optVal == "true")
+                  )
                 )
-              )
 
-          if field.presence == Repeated:
-            value[2][^1][1] = newNimNode(nnkBracketExpr).add(
-              ident("seq"),
-              value[2][^1][1]
-            )
-          elif isReference:
-            value[2][^1][1] = newNimNode(nnkRefTy).add(value[2][^1][1])
+            if field.presence == Repeated:
+              value[2][^1][1] = newNimNode(nnkBracketExpr).add(
+                ident("seq"),
+                value[2][^1][1]
+              )
+            elif isReference:
+              value[2][^1][1] = newNimNode(nnkRefTy).add(value[2][^1][1])
+          else:
+            raiseAssert "Unexpected proto type: " & $field.kind
+
+        # Empty message
         if value[2].len == 0:
           value[2] = newEmptyNode()
 
@@ -262,6 +322,8 @@ proc protoToTypesInternal*(filepath: string, isProto3 = true): NimNode {.compile
             newNimNode(nnkPostfix).add(ident("*"), ident(name)),
             if next.kind == ProtoType.Enum:
               newNimNode(nnkPragma).add(ident("pure"), ident(protoVer))
+            elif next.kind == ProtoType.Oneof:
+              newNimNode(nnkPragma).add(ident(protoVer), ident("oneof"))
             else:
               newNimNode(nnkPragma).add(ident(protoVer))
           ),

--- a/protobuf_serialization/files/type_generator.nim
+++ b/protobuf_serialization/files/type_generator.nim
@@ -122,6 +122,11 @@ proc protoToTypesInternal*(filepath: string, isProto3 = true): NimNode {.compile
         for field in msg.fields:
           if field.kind == ProtoType.Oneof:
             # Oneof does not allow: map, repeated, optional
+            let field = ProtoNode(
+              kind: ProtoType.Oneof,
+              oneofName: msg.messageName & field.oneofName.capitalizeAscii(),
+              oneof: field.oneof
+            )
             queue.add(field)
             # Add oneof case field enum
             var enumVals = @[ProtoNode(kind: ProtoType.EnumVal, fieldName: "unset", num: 0)]
@@ -130,7 +135,7 @@ proc protoToTypesInternal*(filepath: string, isProto3 = true): NimNode {.compile
               enumVals.add ProtoNode(kind: ProtoType.EnumVal, fieldName: f.name, num: i + 1)
             queue.add ProtoNode(
               kind: ProtoType.Enum,
-              enumName: field.oneofName.capitalizeAscii() & "Kind",
+              enumName: field.oneofName & "Kind",
               values: enumVals
             )
           elif field.kind == ProtoType.Field and field.protoType.startsWith("map<"):
@@ -171,7 +176,7 @@ proc protoToTypesInternal*(filepath: string, isProto3 = true): NimNode {.compile
             newIntLitNode(enumField.num)
           ))
       elif next.kind == ProtoType.Oneof:
-        name = next.oneofName.capitalizeAscii()
+        name = next.oneofName
         let caseKind = ident(name & "Kind")
         let caseOf = newNimNode(nnkRecCase).add(
           newIdentDefs(newNimNode(nnkPostfix).add(ident("*"), ident("kind")), caseKind),
@@ -234,8 +239,7 @@ proc protoToTypesInternal*(filepath: string, isProto3 = true): NimNode {.compile
                 ),
                 newNimNode(nnkPragma).add(ident("oneof"))
               ),
-              # XXX namespace
-              ident(field.oneofName.capitalizeAscii()),
+              ident(next.messageName & field.oneofName.capitalizeAscii()),
               newEmptyNode()
             ))
           of ProtoType.Field:

--- a/protobuf_serialization/internal.nim
+++ b/protobuf_serialization/internal.nim
@@ -69,8 +69,14 @@ proc isOneof*(T: type, fieldName: static string): bool {.compileTime.} =
 macro enumOneofFields*(T: type, kName, kVal, fName, fTyp, body: untyped): untyped =
   result = newStmtList()
   let typeImpl = getType(T)[1].getImpl()
+  var discriminatorCount = 0
   for field in recordFields(typeImpl):
     if field.caseField == nil:
+      if not field.isDiscriminator:
+        error repr(typeImpl[0].skipPragma) & "." & $field.name.skipPragma & ": unexpected oneof field"
+      if discriminatorCount > 0:
+        error repr(typeImpl[0].skipPragma) & "." & $field.name.skipPragma & ": only one `case` is allowed"
+      inc discriminatorCount
       continue
     let discriminatorName = newLit($field.caseField[0].skipPragma)
     let fieldName = newLit($field.name.skipPragma)

--- a/protobuf_serialization/internal.nim
+++ b/protobuf_serialization/internal.nim
@@ -66,32 +66,33 @@ proc fieldNumberOf*(T: type, fieldName: static string): int {.compileTime.} =
 proc isOneof*(T: type, fieldName: static string): bool {.compileTime.} =
   T.hasCustomPragmaFixed(fieldName, oneof)
 
-proc getEnumTy(T: NimNode): NimNode =
-  let enumType = T.getTypeImpl()[1]
-  let impl = enumType.getTypeImpl()
-  expectKind(impl, nnkEnumTy)
-  impl
-
-macro enumEnumValues*(T: type enum, enumValue, body: untyped): untyped =
+macro enumOneofFields*(T: type, kName, kVal, fName, fTyp, body: untyped): untyped =
   result = newStmtList()
-  for val in getEnumTy(T):
-    if val.kind == nnkEmpty:
+  let typeImpl = getType(T)[1].getImpl()
+  for field in recordFields(typeImpl):
+    if field.caseField == nil:
       continue
+    let discriminatorName = newLit($field.caseField[0].skipPragma)
+    let fieldName = newLit($field.name.skipPragma)
+    let branchVal = field.caseBranch[0]
+    let fieldTyp = field.typ
     result.add quote do:
       block:
-        const `enumValue` = `val`
+        const `kName` = `discriminatorName`
+        const `fName` = `fieldName`
+        template `kVal`(): untyped =
+          `branchVal`
+        template `fTyp`(): untyped =
+          `fieldTyp`
         `body`
 
-macro resetField(obj: object, fieldName: static string): untyped =
-  let fieldVar = newDotExpr(obj, ident fieldName)
+macro setOneof*(
+    fieldVar: var object, kName: static[string], kVal: untyped, fName: static[string], fVal: untyped
+): untyped =
+  let kind = ident(kName)
+  let field = ident(fName)
   quote do:
-    `fieldVar` = default(typeof(`fieldVar`))
-
-proc resetOneof*(value: var object, setVal: enum) =
-  enumEnumValues(typeof(setVal), enumValue):
-    when ord(enumValue) != 0:
-      if setVal != enumValue:
-        resetField(value, $enumValue)
+    `fieldVar` = typeof(`fieldVar`)(`kind`: `kVal`, `field`: move(`fVal`))
 
 template protoType*(InnerType, RootType, FieldType: untyped, fieldName: untyped) =
   mixin flatType, isExtension
@@ -195,27 +196,30 @@ func verifySerializable*[T](ty: typedesc[T]) {.compileTime.} =
       {.fatal: $T & ": missing {.proto2.} or {.proto3.}".}
 
     enumInstanceSerializedFields(inst, fieldName, fieldVar):
-      when isProto2 and not T.isRequired(fieldName) and
-          fieldVar isnot (seq or PBOption) and
-          not isExtension(Protobuf, typeof(fieldVar)):
-        fieldError T, fieldName, "proto2 requires every field to either have the required pragma attached or be a repeated field/PBOption."
-      when isProto3 and (
-        T.hasCustomPragmaFixed(fieldName, required) or
-        fieldVar is PBOption or
-        isExtension(Protobuf, typeof(fieldVar))
-      ):
-        fieldError T, fieldName, "The required pragma/PBOption type can only be used with proto2."
-
-      protoType(ProtoType {.used.}, T, typeof(fieldVar), fieldName) # Ensure we can form a ProtoType
-
-      const fieldNum = T.fieldNumberOf(fieldName)
-      when not validFieldNumber(fieldNum, strict = true):
-        fieldError T, fieldName, "Field numbers must be in the range [1..2^29-1]"
-
-      if fieldNumberSet.containsOrIncl(fieldNum):
-        raiseAssert $T & "." & fieldName & ": Field number was used twice on two different fields: " & $fieldNum
-
-      when T.hasCustomPragmaFixed(fieldName, ext):
-        discard  # do nothing for extensions; they should validate on read/write
+      when T.isOneof(fieldName):
+        discard # XXX verify
       else:
-        verifySerializable(typeof(fieldVar))
+        when isProto2 and not T.isRequired(fieldName) and
+            fieldVar isnot (seq or PBOption) and
+            not isExtension(Protobuf, typeof(fieldVar)):
+          fieldError T, fieldName, "proto2 requires every field to either have the required pragma attached or be a repeated field/PBOption."
+        when isProto3 and (
+          T.hasCustomPragmaFixed(fieldName, required) or
+          fieldVar is PBOption or
+          isExtension(Protobuf, typeof(fieldVar))
+        ):
+          fieldError T, fieldName, "The required pragma/PBOption type can only be used with proto2."
+
+        protoType(ProtoType {.used.}, T, typeof(fieldVar), fieldName) # Ensure we can form a ProtoType
+
+        const fieldNum = T.fieldNumberOf(fieldName)
+        when not validFieldNumber(fieldNum, strict = true):
+          fieldError T, fieldName, "Field numbers must be in the range [1..2^29-1]"
+
+        if fieldNumberSet.containsOrIncl(fieldNum):
+          raiseAssert $T & "." & fieldName & ": Field number was used twice on two different fields: " & $fieldNum
+
+        when T.hasCustomPragmaFixed(fieldName, ext):
+          discard  # do nothing for extensions; they should validate on read/write
+        else:
+          verifySerializable(typeof(fieldVar))

--- a/protobuf_serialization/internal.nim
+++ b/protobuf_serialization/internal.nim
@@ -238,13 +238,13 @@ func verifySerializable*[T](ty: typedesc[T]) {.compileTime.} =
 
       when T.isOneof(fieldName):
         when T.hasCustomPragmaFixed(fieldName, required):
-          fieldError T, fieldName, "Oneof cannot be {.required.}"
+          fieldError T, fieldName, "Oneof can't be {.required.}"
         elif T.hasCustomPragmaFixed(fieldName, fieldNumber):
-          fieldError T, fieldName, "Oneof cannot be {.fieldNumber: N.}"
+          fieldError T, fieldName, "Oneof can't be {.fieldNumber: N.}"
         elif fieldValTyp is seq:
-          fieldError T, fieldName, $fieldValTyp & " Oneof cannot be seq / repeated"
+          fieldError T, fieldName, $fieldValTyp & " Oneof can't be seq / repeated"
         elif fieldValTyp is PBOption:
-          fieldError T, fieldName, $fieldValTyp & " Oneof cannot be PBOption"
+          fieldError T, fieldName, $fieldValTyp & " Oneof can't be PBOption"
         elif fieldValTyp.isProto2() == fieldValTyp.isProto3():
           fieldError T, fieldName, $fieldValTyp & " object requires either {.proto2.} or {.proto3.}"
         elif not fieldValTyp.hasCustomPragma(oneof):
@@ -261,11 +261,11 @@ func verifySerializable*[T](ty: typedesc[T]) {.compileTime.} =
           when fieldValTyp.hasCustomPragmaFixed(fName, ext):
             discard
           elif fTyp is seq and fTyp isnot seq[byte]:
-            fieldError fieldValTyp, fName, "Oneof field cannot be seq[T] / repeated"
+            fieldError fieldValTyp, fName, "Oneof field can't be seq[T] / repeated"
           elif fTyp is PBOption:
-            fieldError fieldValTyp, fName, "Oneof field cannot be PBOption"
+            fieldError fieldValTyp, fName, "Oneof field can't be PBOption"
           elif fTyp.hasCustomPragma(oneof):
-            fieldError fieldValTyp, fName, "Oneof field cannot be oneof (nested)"
+            fieldError fieldValTyp, fName, "Oneof field can't be oneof (nested)"
           else:
             verifySerializable(fTyp)
       else:

--- a/protobuf_serialization/internal.nim
+++ b/protobuf_serialization/internal.nim
@@ -67,14 +67,14 @@ proc isOneof*(T: type, fieldName: static string): bool {.compileTime.} =
   T.hasCustomPragmaFixed(fieldName, oneof)
 
 proc getIdent(n: NimNode): NimNode =
-  ## Skip pragmas and `*`
+  ## Skip pragmas and `*` and return a fresh ident
   case n.kind
   of nnkPragmaExpr:
     getIdent(n[0])
   of nnkPostfix:
     getIdent(n[1])
-  of nnkIdent:
-    n
+  of nnkSym, nnkIdent:
+    ident($n)
   else:
     raiseAssert "Expected ident but found: " & $n.kind
 
@@ -86,9 +86,9 @@ macro enumOneofFields*(T: type, kName, kVal, fName, fTyp, body: untyped): untype
   for field in recordFields(typeImpl):
     if field.caseField == nil:
       if not field.isDiscriminator:
-        error repr(typeImpl[0].getIdent()) & "." & $field.name.getIdent() & ": unexpected oneof field; field must be within a `case` branch"
+        error $typeImpl[0].getIdent() & "." & $field.name.getIdent() & ": unexpected oneof field; field must be within a `case` branch"
       if discriminatorCount > 0:
-        error repr(typeImpl[0].getIdent()) & "." & $field.name.getIdent() & ": only one `case` is allowed"
+        error $typeImpl[0].getIdent() & "." & $field.name.getIdent() & ": only one `case` is allowed"
       inc discriminatorCount
     else:
       let discriminatorName = newLit($field.caseField[0].getIdent())
@@ -96,7 +96,7 @@ macro enumOneofFields*(T: type, kName, kVal, fName, fTyp, body: untyped): untype
       let fieldTyp = field.typ
       let branchVal = field.caseBranch[0]
       if branchVal == lastBranch:
-        error repr(typeImpl[0].getIdent()) & "." & $field.name.getIdent() & ": only one field is allowed per branch"
+        error $typeImpl[0].getIdent() & "." & $field.name.getIdent() & ": only one field is allowed per branch"
       lastBranch = branchVal
       result.add quote do:
         block:
@@ -107,6 +107,9 @@ macro enumOneofFields*(T: type, kName, kVal, fName, fTyp, body: untyped): untype
           template `fTyp`(): untyped {.used.} =
             `fieldTyp`
           `body`
+
+macro oneofVar*(fieldVar: var object, fName: static[string]): untyped =
+  newDotExpr(fieldVar, ident(fName))
 
 macro setOneof*(
     fieldVar: var object, kName: static[string], kVal: untyped, fName: static[string], fVal: untyped
@@ -122,7 +125,7 @@ macro oneofCaseOf*(T: type, value, fVar, fName, body: untyped): untyped =
   for field in recordFields(typeImpl):
     if field.caseField == nil:
       doAssert caseStmt.len == 0
-      caseStmt.add newDotExpr(value, ident($field.name.getIdent()))
+      caseStmt.add newDotExpr(value, field.name.getIdent())
       let enumTyp = field.typ
       let defVal = quote do: default(typeof(`enumTyp`))
       let discardStmt = quote do: discard
@@ -131,7 +134,7 @@ macro oneofCaseOf*(T: type, value, fVar, fName, body: untyped): untyped =
       doAssert caseStmt.len > 0
       let branchVal = field.caseBranch[0]
       let fieldName = newLit($field.name.getIdent())
-      let fieldVal = newDotExpr(value, ident($field.name.getIdent()))
+      let fieldVal = newDotExpr(value, field.name.getIdent())
       let body2 = quote do:
         const `fName` {.used.} = `fieldName`
         template `fVar`(): untyped {.used.} =

--- a/protobuf_serialization/internal.nim
+++ b/protobuf_serialization/internal.nim
@@ -66,14 +66,17 @@ proc fieldNumberOf*(T: type, fieldName: static string): int {.compileTime.} =
 proc isOneof*(T: type, fieldName: static string): bool {.compileTime.} =
   T.hasCustomPragmaFixed(fieldName, oneof)
 
-proc stripped(n: NimNode): NimNode =
+proc getIdent(n: NimNode): NimNode =
+  ## Skip pragmas and `*`
   case n.kind
-  of nnkPostfix: stripped(n[1])
-  of nnkPragmaExpr: stripped(n[0])
-  of nnkIdentDefs: stripped(n[0])
-  else:
-    #doAssert n.kind == nnkIdent
+  of nnkPragmaExpr:
+    getIdent(n[0])
+  of nnkPostfix:
+    getIdent(n[1])
+  of nnkIdent:
     n
+  else:
+    raiseAssert "Expected ident but found: " & $n.kind
 
 macro enumOneofFields*(T: type, kName, kVal, fName, fTyp, body: untyped): untyped =
   result = newStmtList()
@@ -83,17 +86,17 @@ macro enumOneofFields*(T: type, kName, kVal, fName, fTyp, body: untyped): untype
   for field in recordFields(typeImpl):
     if field.caseField == nil:
       if not field.isDiscriminator:
-        error repr(typeImpl[0].stripped) & "." & $field.name.stripped & ": unexpected oneof field; field must be within a `case` branch"
+        error repr(typeImpl[0].getIdent()) & "." & $field.name.getIdent() & ": unexpected oneof field; field must be within a `case` branch"
       if discriminatorCount > 0:
-        error repr(typeImpl[0].stripped) & "." & $field.name.stripped & ": only one `case` is allowed"
+        error repr(typeImpl[0].getIdent()) & "." & $field.name.getIdent() & ": only one `case` is allowed"
       inc discriminatorCount
     else:
-      let discriminatorName = newLit($field.caseField[0].stripped)
-      let fieldName = newLit($field.name.stripped)
+      let discriminatorName = newLit($field.caseField[0].getIdent())
+      let fieldName = newLit($field.name.getIdent())
       let fieldTyp = field.typ
       let branchVal = field.caseBranch[0]
       if branchVal == lastBranch:
-        error repr(typeImpl[0].stripped) & "." & $field.name.stripped & ": only one field is allowed per branch"
+        error repr(typeImpl[0].getIdent()) & "." & $field.name.getIdent() & ": only one field is allowed per branch"
       lastBranch = branchVal
       result.add quote do:
         block:
@@ -119,7 +122,7 @@ macro oneofCaseOf*(T: type, value, fVar, fName, body: untyped): untyped =
   for field in recordFields(typeImpl):
     if field.caseField == nil:
       doAssert caseStmt.len == 0
-      caseStmt.add newDotExpr(value, ident($field.name.stripped))
+      caseStmt.add newDotExpr(value, ident($field.name.getIdent()))
       let enumTyp = field.typ
       let defVal = quote do: default(typeof(`enumTyp`))
       let discardStmt = quote do: discard
@@ -127,8 +130,8 @@ macro oneofCaseOf*(T: type, value, fVar, fName, body: untyped): untyped =
     else:
       doAssert caseStmt.len > 0
       let branchVal = field.caseBranch[0]
-      let fieldName = newLit($field.name.stripped)
-      let fieldVal = newDotExpr(value, ident($field.name.stripped))
+      let fieldName = newLit($field.name.getIdent())
+      let fieldVal = newDotExpr(value, ident($field.name.getIdent()))
       let body2 = quote do:
         const `fName` {.used.} = `fieldName`
         template `fVar`(): untyped {.used.} =

--- a/protobuf_serialization/internal.nim
+++ b/protobuf_serialization/internal.nim
@@ -101,17 +101,18 @@ macro setOneof*(
     `fieldVar` = typeof(`fieldVar`)(`kind`: `kVal`, `field`: move(`fVal`))
 
 macro oneofCaseOf*(T: type, value, fVar, fName, body: untyped): untyped =
-  result = newStmtList()
   var caseStmt = newSeq[NimNode]()
   let typeImpl = getType(T)[1].getImpl()
-  var enumTyp: NimNode = nil
   for field in recordFields(typeImpl):
     if field.caseField == nil:
-      doAssert enumTyp == nil
-      enumTyp = field.typ
+      doAssert caseStmt.len == 0
       caseStmt.add newDotExpr(value, ident($field.name.skipPragma))
+      let enumTyp = field.typ
+      let defVal = quote do: default(typeof(`enumTyp`))
+      let discardStmt = quote do: discard
+      caseStmt.add newTree(nnkOfBranch, defVal, discardStmt)
     else:
-      doAssert enumTyp != nil
+      doAssert caseStmt.len > 0
       let branchVal = field.caseBranch[0]
       let fieldName = newLit($field.name.skipPragma)
       let fieldVal = newDotExpr(value, ident($field.name.skipPragma))
@@ -122,10 +123,7 @@ macro oneofCaseOf*(T: type, value, fVar, fName, body: untyped): untyped =
         `body`
       caseStmt.add newTree(nnkOfBranch, branchVal, body2)
   doAssert caseStmt.len > 0
-  let defVal = quote do: default(typeof(`enumTyp`))
-  let discardStmt = quote do: discard
-  caseStmt.add newTree(nnkOfBranch, defVal, discardStmt)
-  result.add newTree(nnkCaseStmt, caseStmt)
+  newStmtList().add(newTree(nnkCaseStmt, caseStmt))
 
 template protoType*(InnerType, RootType, FieldType: untyped, fieldName: untyped) =
   mixin flatType, isExtension

--- a/protobuf_serialization/internal.nim
+++ b/protobuf_serialization/internal.nim
@@ -108,9 +108,6 @@ macro enumOneofFields*(T: type, kName, kVal, fName, fTyp, body: untyped): untype
             `fieldTyp`
           `body`
 
-macro oneofVar*(fieldVar: var object, fName: static[string]): untyped =
-  newDotExpr(fieldVar, ident(fName))
-
 macro setOneof*(
     fieldVar: var object, kName: static[string], kVal: untyped, fName: static[string], fVal: untyped
 ): untyped =

--- a/protobuf_serialization/internal.nim
+++ b/protobuf_serialization/internal.nim
@@ -4,6 +4,7 @@
 
 import std/[options, sets]
 import stew/shims/macros
+from std/strutils import parseEnum
 #Depending on the situation, one of these two are used.
 #Sometimes, one works where the other doesn't.
 #It all comes down to bugs in Nim and managing them.
@@ -62,6 +63,24 @@ proc fieldNumberOf*(T: type, fieldName: static string): int {.compileTime.} =
     fieldError T, fieldName, "Missing {.fieldNumber: N.}"
   else:
     fieldNum
+
+proc isOneof*(T: type, fieldName: static string): bool {.compileTime.} =
+  T.hasCustomPragmaFixed(fieldName, oneof)
+
+template setOneof*(obj: object, headerNum: int): untyped =
+  type T = typeof(obj)
+  for fieldName, fieldVar in fieldPairs(obj):
+    when fieldName == "kind":
+      enumInstanceSerializedFields(obj, fieldName2, fieldVar2):
+        if headerNum == T.fieldNumberOf(fieldName2):
+          try:
+            fieldVar = parseEnum[typeof(fieldVar)](fieldName2)
+          except ValueError:
+            raiseAssert "unexpected oneof field " & fieldName2
+    else:
+      # XXX skip dontSerialize
+      if headerNum != T.fieldNumberOf(fieldName):
+        fieldVar = default(typeof(fieldVar))
 
 template protoType*(InnerType, RootType, FieldType: untyped, fieldName: untyped) =
   mixin flatType, isExtension

--- a/protobuf_serialization/internal.nim
+++ b/protobuf_serialization/internal.nim
@@ -66,6 +66,15 @@ proc fieldNumberOf*(T: type, fieldName: static string): int {.compileTime.} =
 proc isOneof*(T: type, fieldName: static string): bool {.compileTime.} =
   T.hasCustomPragmaFixed(fieldName, oneof)
 
+proc stripped(n: NimNode): NimNode =
+  case n.kind
+  of nnkPostfix: stripped(n[1])
+  of nnkPragmaExpr: stripped(n[0])
+  of nnkIdentDefs: stripped(n[0])
+  else:
+    #doAssert n.kind == nnkIdent
+    n
+
 macro enumOneofFields*(T: type, kName, kVal, fName, fTyp, body: untyped): untyped =
   result = newStmtList()
   let typeImpl = getType(T)[1].getImpl()
@@ -74,17 +83,17 @@ macro enumOneofFields*(T: type, kName, kVal, fName, fTyp, body: untyped): untype
   for field in recordFields(typeImpl):
     if field.caseField == nil:
       if not field.isDiscriminator:
-        error repr(typeImpl[0].skipPragma) & "." & $field.name.skipPragma & ": unexpected oneof field; field must be within a `case` branch"
+        error repr(typeImpl[0].stripped) & "." & $field.name.stripped & ": unexpected oneof field; field must be within a `case` branch"
       if discriminatorCount > 0:
-        error repr(typeImpl[0].skipPragma) & "." & $field.name.skipPragma & ": only one `case` is allowed"
+        error repr(typeImpl[0].stripped) & "." & $field.name.stripped & ": only one `case` is allowed"
       inc discriminatorCount
     else:
-      let discriminatorName = newLit($field.caseField[0].skipPragma)
-      let fieldName = newLit($field.name.skipPragma)
+      let discriminatorName = newLit($field.caseField[0].stripped)
+      let fieldName = newLit($field.name.stripped)
       let fieldTyp = field.typ
       let branchVal = field.caseBranch[0]
       if branchVal == lastBranch:
-        error repr(typeImpl[0].skipPragma) & "." & $field.name.skipPragma & ": only one field is allowed per branch"
+        error repr(typeImpl[0].stripped) & "." & $field.name.stripped & ": only one field is allowed per branch"
       lastBranch = branchVal
       result.add quote do:
         block:
@@ -110,7 +119,7 @@ macro oneofCaseOf*(T: type, value, fVar, fName, body: untyped): untyped =
   for field in recordFields(typeImpl):
     if field.caseField == nil:
       doAssert caseStmt.len == 0
-      caseStmt.add newDotExpr(value, ident($field.name.skipPragma))
+      caseStmt.add newDotExpr(value, ident($field.name.stripped))
       let enumTyp = field.typ
       let defVal = quote do: default(typeof(`enumTyp`))
       let discardStmt = quote do: discard
@@ -118,8 +127,8 @@ macro oneofCaseOf*(T: type, value, fVar, fName, body: untyped): untyped =
     else:
       doAssert caseStmt.len > 0
       let branchVal = field.caseBranch[0]
-      let fieldName = newLit($field.name.skipPragma)
-      let fieldVal = newDotExpr(value, ident($field.name.skipPragma))
+      let fieldName = newLit($field.name.stripped)
+      let fieldVal = newDotExpr(value, ident($field.name.stripped))
       let body2 = quote do:
         const `fName` {.used.} = `fieldName`
         template `fVar`(): untyped {.used.} =

--- a/protobuf_serialization/internal.nim
+++ b/protobuf_serialization/internal.nim
@@ -70,6 +70,7 @@ macro enumOneofFields*(T: type, kName, kVal, fName, fTyp, body: untyped): untype
   result = newStmtList()
   let typeImpl = getType(T)[1].getImpl()
   var discriminatorCount = 0
+  var lastBranch: NimNode = nil
   for field in recordFields(typeImpl):
     if field.caseField == nil:
       if not field.isDiscriminator:
@@ -77,20 +78,23 @@ macro enumOneofFields*(T: type, kName, kVal, fName, fTyp, body: untyped): untype
       if discriminatorCount > 0:
         error repr(typeImpl[0].skipPragma) & "." & $field.name.skipPragma & ": only one `case` is allowed"
       inc discriminatorCount
-      continue
-    let discriminatorName = newLit($field.caseField[0].skipPragma)
-    let fieldName = newLit($field.name.skipPragma)
-    let branchVal = field.caseBranch[0]
-    let fieldTyp = field.typ
-    result.add quote do:
-      block:
-        const `kName` = `discriminatorName`
-        const `fName` = `fieldName`
-        template `kVal`(): untyped =
-          `branchVal`
-        template `fTyp`(): untyped =
-          `fieldTyp`
-        `body`
+    else:
+      let discriminatorName = newLit($field.caseField[0].skipPragma)
+      let fieldName = newLit($field.name.skipPragma)
+      let fieldTyp = field.typ
+      let branchVal = field.caseBranch[0]
+      if branchVal == lastBranch:
+        error repr(typeImpl[0].skipPragma) & "." & $field.name.skipPragma & ": only one field is allowed per branch"
+      lastBranch = branchVal
+      result.add quote do:
+        block:
+          const `kName` {.used.} = `discriminatorName`
+          const `fName` {.used.} = `fieldName`
+          template `kVal`(): untyped {.used.} =
+            `branchVal`
+          template `fTyp`(): untyped {.used.} =
+            `fieldTyp`
+          `body`
 
 macro setOneof*(
     fieldVar: var object, kName: static[string], kVal: untyped, fName: static[string], fVal: untyped
@@ -117,8 +121,8 @@ macro oneofCaseOf*(T: type, value, fVar, fName, body: untyped): untyped =
       let fieldName = newLit($field.name.skipPragma)
       let fieldVal = newDotExpr(value, ident($field.name.skipPragma))
       let body2 = quote do:
-        const `fName` = `fieldName`
-        template `fVar`(): untyped =
+        const `fName` {.used.} = `fieldName`
+        template `fVar`(): untyped {.used.} =
           `fieldVal`
         `body`
       caseStmt.add newTree(nnkOfBranch, branchVal, body2)
@@ -226,22 +230,41 @@ func verifySerializable*[T](ty: typedesc[T]) {.compileTime.} =
     when isProto2 == isProto3:
       {.fatal: $T & ": missing {.proto2.} or {.proto3.}".}
 
-    enumInstanceSerializedFields(inst, fieldName, fieldVar):
+    enumInstanceSerializedFields(inst, fieldName, fieldVal):
+      template fieldValTyp(): untyped =
+        typeof(fieldVal)
+
       when T.isOneof(fieldName):
-        discard # XXX verify
+        when fieldValTyp.isProto2() == fieldValTyp.isProto3():
+          fieldError T, fieldName, $fieldValTyp & " requires either {.proto2.} or {.proto3.}"
+        when not fieldValTyp.hasCustomPragma(oneof):
+          fieldError T, fieldName, $fieldValTyp & " missing {.oneof.}"
+        enumOneofFields(fieldValTyp, kName, kVal, fName, fTyp):
+          when kVal == default(typeof(kVal)):
+            fieldError fieldValTyp, fName, "oneof default unset value branch must not contain any field"
+          protoType(ProtoType {.used.}, fieldValTyp, fTyp, fName)
+          const fieldNum = fieldValTyp.fieldNumberOf(fName)
+          when not validFieldNumber(fieldNum, strict = true):
+            fieldError fieldValTyp, fName, "Field numbers must be in the range [1..2^29-1]"
+          if fieldNumberSet.containsOrIncl(fieldNum):
+            raiseAssert $T & "." & fieldName & ": " & $fieldValTyp & "." & fName & ": Field number was used twice on two different fields: " & $fieldNum
+          when fieldValTyp.hasCustomPragmaFixed(fName, ext):
+            discard
+          else:
+            verifySerializable(fTyp)
       else:
         when isProto2 and not T.isRequired(fieldName) and
-            fieldVar isnot (seq or PBOption) and
-            not isExtension(Protobuf, typeof(fieldVar)):
+            fieldVal isnot (seq or PBOption) and
+            not isExtension(Protobuf, fieldValTyp):
           fieldError T, fieldName, "proto2 requires every field to either have the required pragma attached or be a repeated field/PBOption."
         when isProto3 and (
           T.hasCustomPragmaFixed(fieldName, required) or
-          fieldVar is PBOption or
-          isExtension(Protobuf, typeof(fieldVar))
+          fieldVal is PBOption or
+          isExtension(Protobuf, fieldValTyp)
         ):
           fieldError T, fieldName, "The required pragma/PBOption type can only be used with proto2."
 
-        protoType(ProtoType {.used.}, T, typeof(fieldVar), fieldName) # Ensure we can form a ProtoType
+        protoType(ProtoType {.used.}, T, fieldValTyp, fieldName) # Ensure we can form a ProtoType
 
         const fieldNum = T.fieldNumberOf(fieldName)
         when not validFieldNumber(fieldNum, strict = true):
@@ -253,4 +276,4 @@ func verifySerializable*[T](ty: typedesc[T]) {.compileTime.} =
         when T.hasCustomPragmaFixed(fieldName, ext):
           discard  # do nothing for extensions; they should validate on read/write
         else:
-          verifySerializable(typeof(fieldVar))
+          verifySerializable(fieldValTyp)

--- a/protobuf_serialization/internal.nim
+++ b/protobuf_serialization/internal.nim
@@ -74,7 +74,7 @@ macro enumOneofFields*(T: type, kName, kVal, fName, fTyp, body: untyped): untype
   for field in recordFields(typeImpl):
     if field.caseField == nil:
       if not field.isDiscriminator:
-        error repr(typeImpl[0].skipPragma) & "." & $field.name.skipPragma & ": unexpected oneof field"
+        error repr(typeImpl[0].skipPragma) & "." & $field.name.skipPragma & ": unexpected oneof field; field must be within a `case` branch"
       if discriminatorCount > 0:
         error repr(typeImpl[0].skipPragma) & "." & $field.name.skipPragma & ": only one `case` is allowed"
       inc discriminatorCount
@@ -229,19 +229,29 @@ func verifySerializable*[T](ty: typedesc[T]) {.compileTime.} =
       isProto3 = T.isProto3()
     when isProto2 == isProto3:
       {.fatal: $T & ": missing {.proto2.} or {.proto3.}".}
+    when T.hasCustomPragma(oneof):
+      {.fatal: $T & ": unexpected oneof value; missing {.oneof.} field?".}
 
     enumInstanceSerializedFields(inst, fieldName, fieldVal):
       template fieldValTyp(): untyped =
         typeof(fieldVal)
 
       when T.isOneof(fieldName):
-        when fieldValTyp.isProto2() == fieldValTyp.isProto3():
-          fieldError T, fieldName, $fieldValTyp & " requires either {.proto2.} or {.proto3.}"
-        when not fieldValTyp.hasCustomPragma(oneof):
-          fieldError T, fieldName, $fieldValTyp & " missing {.oneof.}"
+        when T.hasCustomPragmaFixed(fieldName, required):
+          fieldError T, fieldName, "Oneof cannot be {.required.}"
+        elif T.hasCustomPragmaFixed(fieldName, fieldNumber):
+          fieldError T, fieldName, "Oneof cannot be {.fieldNumber: N.}"
+        elif fieldValTyp is seq:
+          fieldError T, fieldName, $fieldValTyp & " Oneof cannot be seq / repeated"
+        elif fieldValTyp is PBOption:
+          fieldError T, fieldName, $fieldValTyp & " Oneof cannot be PBOption"
+        elif fieldValTyp.isProto2() == fieldValTyp.isProto3():
+          fieldError T, fieldName, $fieldValTyp & " object requires either {.proto2.} or {.proto3.}"
+        elif not fieldValTyp.hasCustomPragma(oneof):
+          fieldError T, fieldName, $fieldValTyp & " object missing {.oneof.}"
         enumOneofFields(fieldValTyp, kName, kVal, fName, fTyp):
           when kVal == default(typeof(kVal)):
-            fieldError fieldValTyp, fName, "oneof default unset value branch must not contain any field"
+            fieldError fieldValTyp, fName, "Oneof branch of default value (unset) must not contain any field"
           protoType(ProtoType {.used.}, fieldValTyp, fTyp, fName)
           const fieldNum = fieldValTyp.fieldNumberOf(fName)
           when not validFieldNumber(fieldNum, strict = true):
@@ -250,6 +260,12 @@ func verifySerializable*[T](ty: typedesc[T]) {.compileTime.} =
             raiseAssert $T & "." & fieldName & ": " & $fieldValTyp & "." & fName & ": Field number was used twice on two different fields: " & $fieldNum
           when fieldValTyp.hasCustomPragmaFixed(fName, ext):
             discard
+          elif fTyp is seq and fTyp isnot seq[byte]:
+            fieldError fieldValTyp, fName, "Oneof field cannot be seq[T] / repeated"
+          elif fTyp is PBOption:
+            fieldError fieldValTyp, fName, "Oneof field cannot be PBOption"
+          elif fTyp.hasCustomPragma(oneof):
+            fieldError fieldValTyp, fName, "Oneof field cannot be oneof (nested)"
           else:
             verifySerializable(fTyp)
       else:

--- a/protobuf_serialization/internal.nim
+++ b/protobuf_serialization/internal.nim
@@ -4,7 +4,6 @@
 
 import std/[options, sets]
 import stew/shims/macros
-from std/strutils import parseEnum
 #Depending on the situation, one of these two are used.
 #Sometimes, one works where the other doesn't.
 #It all comes down to bugs in Nim and managing them.
@@ -25,13 +24,20 @@ template flatType*(T: type Protobuf, value: auto): type =
   typeof(flatTypeInternal(value))
 
 template unsupportedProtoType*(FieldType, RootType, fieldName: untyped): untyped =
-  {.fatal: "Serializing " & $FieldType & " as field type is not supported: " & $RootType & "." & fieldName.}
+  {.
+    fatal:
+      "Serializing " & $FieldType & " as field type is not supported: " & $RootType & "." &
+      fieldName
+  .}
 
 template fieldError(T: type, name, msg: static string) =
   {.fatal: $T & "." & name & ": " & msg.}
 
-proc isProto2*(T: type): bool {.compileTime.} = T.hasCustomPragma(proto2)
-proc isProto3*(T: type): bool {.compileTime.} = T.hasCustomPragma(proto3)
+proc isProto2*(T: type): bool {.compileTime.} =
+  T.hasCustomPragma(proto2)
+
+proc isProto3*(T: type): bool {.compileTime.} =
+  T.hasCustomPragma(proto3)
 
 proc isPacked*(T: type, fieldName: static string): Option[bool] {.compileTime.} =
   if T.hasCustomPragmaFixed(fieldName, packed):
@@ -55,7 +61,8 @@ proc supportsPacked*(T: type, ProtoType: type ProtobufExt): bool =
   else:
     unsupportedProtoType ProtoType.FieldType, ProtoType.RootType, ProtoType.fieldName
 
-template isExtension(T: type Protobuf, FieldType: type): bool = false
+template isExtension(T: type Protobuf, FieldType: type): bool =
+  false
 
 proc fieldNumberOf*(T: type, fieldName: static string): int {.compileTime.} =
   const fieldNum = T.getCustomPragmaFixed(fieldName, fieldNumber)
@@ -67,26 +74,46 @@ proc fieldNumberOf*(T: type, fieldName: static string): int {.compileTime.} =
 proc isOneof*(T: type, fieldName: static string): bool {.compileTime.} =
   T.hasCustomPragmaFixed(fieldName, oneof)
 
-template setOneof*(obj: object, headerNum: int): untyped =
-  type T = typeof(obj)
-  for fieldName, fieldVar in fieldPairs(obj):
-    when fieldName == "kind":
-      enumInstanceSerializedFields(obj, fieldName2, fieldVar2):
-        if headerNum == T.fieldNumberOf(fieldName2):
-          try:
-            fieldVar = parseEnum[typeof(fieldVar)](fieldName2)
-          except ValueError:
-            raiseAssert "unexpected oneof field " & fieldName2
-    else:
-      # XXX skip dontSerialize
-      if headerNum != T.fieldNumberOf(fieldName):
-        fieldVar = default(typeof(fieldVar))
+proc getEnumTy(T: NimNode): NimNode =
+  let enumType = T.getTypeImpl()[1]
+  let impl = enumType.getTypeImpl()
+  expectKind(impl, nnkEnumTy)
+  impl
+
+macro enumEnumValues*(T: type enum, enumValue, body: untyped): untyped =
+  result = newStmtList()
+  for val in getEnumTy(T):
+    if val.kind == nnkEmpty:
+      continue
+    result.add quote do:
+      block:
+        const `enumValue` = `val`
+        `body`
+
+macro resetField(obj: object, fieldName: static string): untyped =
+  let fieldVar = newDotExpr(obj, ident fieldName)
+  quote:
+    `fieldVar` = default(typeof(`fieldVar`))
+
+proc resetOneof*(value: var object, setVal: enum) =
+  enumEnumValues(typeof(setVal), enumValue):
+    when ord(enumValue) != 0:
+      if setVal != enumValue:
+        resetField(value, $enumValue)
 
 template protoType*(InnerType, RootType, FieldType: untyped, fieldName: untyped) =
   mixin flatType, isExtension
 
   when FieldType is seq and FieldType isnot seq[byte]:
-    type FlatType = Protobuf.flatType(default(typeof(for a in default(FieldType): a)))
+    type FlatType = Protobuf.flatType(
+      default(
+        typeof(
+          for a in default(FieldType):
+            a
+        )
+      )
+    )
+
   else:
     type FlatType = Protobuf.flatType(default(FieldType))
 
@@ -95,14 +122,15 @@ template protoType*(InnerType, RootType, FieldType: untyped, fieldName: untyped)
     isSint = RootType.hasCustomPragmaFixed(fieldName, sint)
     isFixed = RootType.hasCustomPragmaFixed(fieldName, fixed)
     isInteger =
-      (FlatType is int32) or (FlatType is int64) or
-      (FlatType is uint32) or (FlatType) is uint64
+      (FlatType is int32) or (FlatType is int64) or (FlatType is uint32) or
+      (FlatType) is uint64
 
   when ord(isPint) + ord(isSint) + ord(isFixed) != ord(isInteger):
     when isInteger:
       fieldError RootType, fieldName, "Must specify one of `pint`, `sint` and `fixed`"
     else:
-      fieldError RootType, fieldName, "`pint`, `sint` and `fixed` should only be used with integers"
+      fieldError RootType,
+        fieldName, "`pint`, `sint` and `fixed` should only be used with integers"
 
   when RootType.hasCustomPragmaFixed(fieldName, ext) or isExtension(Protobuf, FieldType):
     type InnerType = ProtobufExt[FieldType, RootType, fieldName]
@@ -153,17 +181,24 @@ template protoType*(InnerType, RootType, FieldType: untyped, fieldName: untyped)
   else:
     unsupportedProtoType(FieldType, RootType, fieldName)
 
-template elementType[T](_: type seq[T]): type = typeof(T)
+template elementType[T](_: type seq[T]): type =
+  typeof(T)
 
 func verifySerializable*[T](ty: typedesc[T]) {.compileTime.} =
   mixin flatType, isExtension
 
   type FlatType = Protobuf.flatType(default(T))
   when T is PBOption or isExtension(Protobuf, T):
-    static: doAssert FlatType isnot T  # avoid infinite recursion
+    static:
+      doAssert FlatType isnot T
+      # avoid infinite recursion
     verifySerializable(FlatType)
   elif FlatType is int | uint:
-    {.fatal: $T & ": Serializing a number requires specifying the amount of bits via the type.".}
+    {.
+      fatal:
+        $T &
+        ": Serializing a number requires specifying the amount of bits via the type."
+    .}
   elif FlatType is seq:
     when FlatType isnot seq[byte]:
       when defined(ConformanceTest):
@@ -184,27 +219,30 @@ func verifySerializable*[T](ty: typedesc[T]) {.compileTime.} =
       {.fatal: $T & ": missing {.proto2.} or {.proto3.}".}
 
     enumInstanceSerializedFields(inst, fieldName, fieldVar):
-      when isProto2 and not T.isRequired(fieldName) and
-          fieldVar isnot (seq or PBOption) and
+      when isProto2 and not T.isRequired(fieldName) and fieldVar isnot (seq or PBOption) and
           not isExtension(Protobuf, typeof(fieldVar)):
-        fieldError T, fieldName, "proto2 requires every field to either have the required pragma attached or be a repeated field/PBOption."
+        fieldError T,
+          fieldName,
+          "proto2 requires every field to either have the required pragma attached or be a repeated field/PBOption."
       when isProto3 and (
-        T.hasCustomPragmaFixed(fieldName, required) or
-        fieldVar is PBOption or
+        T.hasCustomPragmaFixed(fieldName, required) or fieldVar is PBOption or
         isExtension(Protobuf, typeof(fieldVar))
       ):
-        fieldError T, fieldName, "The required pragma/PBOption type can only be used with proto2."
+        fieldError T,
+          fieldName, "The required pragma/PBOption type can only be used with proto2."
 
-      protoType(ProtoType {.used.}, T, typeof(fieldVar), fieldName) # Ensure we can form a ProtoType
+      protoType(ProtoType {.used.}, T, typeof(fieldVar), fieldName)
+        # Ensure we can form a ProtoType
 
       const fieldNum = T.fieldNumberOf(fieldName)
       when not validFieldNumber(fieldNum, strict = true):
         fieldError T, fieldName, "Field numbers must be in the range [1..2^29-1]"
 
       if fieldNumberSet.containsOrIncl(fieldNum):
-        raiseAssert $T & "." & fieldName & ": Field number was used twice on two different fields: " & $fieldNum
+        raiseAssert $T & "." & fieldName &
+          ": Field number was used twice on two different fields: " & $fieldNum
 
       when T.hasCustomPragmaFixed(fieldName, ext):
-        discard  # do nothing for extensions; they should validate on read/write
+        discard # do nothing for extensions; they should validate on read/write
       else:
         verifySerializable(typeof(fieldVar))

--- a/protobuf_serialization/internal.nim
+++ b/protobuf_serialization/internal.nim
@@ -24,20 +24,13 @@ template flatType*(T: type Protobuf, value: auto): type =
   typeof(flatTypeInternal(value))
 
 template unsupportedProtoType*(FieldType, RootType, fieldName: untyped): untyped =
-  {.
-    fatal:
-      "Serializing " & $FieldType & " as field type is not supported: " & $RootType & "." &
-      fieldName
-  .}
+  {.fatal: "Serializing " & $FieldType & " as field type is not supported: " & $RootType & "." & fieldName.}
 
 template fieldError(T: type, name, msg: static string) =
   {.fatal: $T & "." & name & ": " & msg.}
 
-proc isProto2*(T: type): bool {.compileTime.} =
-  T.hasCustomPragma(proto2)
-
-proc isProto3*(T: type): bool {.compileTime.} =
-  T.hasCustomPragma(proto3)
+proc isProto2*(T: type): bool {.compileTime.} = T.hasCustomPragma(proto2)
+proc isProto3*(T: type): bool {.compileTime.} = T.hasCustomPragma(proto3)
 
 proc isPacked*(T: type, fieldName: static string): Option[bool] {.compileTime.} =
   if T.hasCustomPragmaFixed(fieldName, packed):
@@ -61,8 +54,7 @@ proc supportsPacked*(T: type, ProtoType: type ProtobufExt): bool =
   else:
     unsupportedProtoType ProtoType.FieldType, ProtoType.RootType, ProtoType.fieldName
 
-template isExtension(T: type Protobuf, FieldType: type): bool =
-  false
+template isExtension(T: type Protobuf, FieldType: type): bool = false
 
 proc fieldNumberOf*(T: type, fieldName: static string): int {.compileTime.} =
   const fieldNum = T.getCustomPragmaFixed(fieldName, fieldNumber)
@@ -92,7 +84,7 @@ macro enumEnumValues*(T: type enum, enumValue, body: untyped): untyped =
 
 macro resetField(obj: object, fieldName: static string): untyped =
   let fieldVar = newDotExpr(obj, ident fieldName)
-  quote:
+  quote do:
     `fieldVar` = default(typeof(`fieldVar`))
 
 proc resetOneof*(value: var object, setVal: enum) =
@@ -105,15 +97,7 @@ template protoType*(InnerType, RootType, FieldType: untyped, fieldName: untyped)
   mixin flatType, isExtension
 
   when FieldType is seq and FieldType isnot seq[byte]:
-    type FlatType = Protobuf.flatType(
-      default(
-        typeof(
-          for a in default(FieldType):
-            a
-        )
-      )
-    )
-
+    type FlatType = Protobuf.flatType(default(typeof(for a in default(FieldType): a)))
   else:
     type FlatType = Protobuf.flatType(default(FieldType))
 
@@ -122,15 +106,14 @@ template protoType*(InnerType, RootType, FieldType: untyped, fieldName: untyped)
     isSint = RootType.hasCustomPragmaFixed(fieldName, sint)
     isFixed = RootType.hasCustomPragmaFixed(fieldName, fixed)
     isInteger =
-      (FlatType is int32) or (FlatType is int64) or (FlatType is uint32) or
-      (FlatType) is uint64
+      (FlatType is int32) or (FlatType is int64) or
+      (FlatType is uint32) or (FlatType) is uint64
 
   when ord(isPint) + ord(isSint) + ord(isFixed) != ord(isInteger):
     when isInteger:
       fieldError RootType, fieldName, "Must specify one of `pint`, `sint` and `fixed`"
     else:
-      fieldError RootType,
-        fieldName, "`pint`, `sint` and `fixed` should only be used with integers"
+      fieldError RootType, fieldName, "`pint`, `sint` and `fixed` should only be used with integers"
 
   when RootType.hasCustomPragmaFixed(fieldName, ext) or isExtension(Protobuf, FieldType):
     type InnerType = ProtobufExt[FieldType, RootType, fieldName]
@@ -181,24 +164,17 @@ template protoType*(InnerType, RootType, FieldType: untyped, fieldName: untyped)
   else:
     unsupportedProtoType(FieldType, RootType, fieldName)
 
-template elementType[T](_: type seq[T]): type =
-  typeof(T)
+template elementType[T](_: type seq[T]): type = typeof(T)
 
 func verifySerializable*[T](ty: typedesc[T]) {.compileTime.} =
   mixin flatType, isExtension
 
   type FlatType = Protobuf.flatType(default(T))
   when T is PBOption or isExtension(Protobuf, T):
-    static:
-      doAssert FlatType isnot T
-      # avoid infinite recursion
+    static: doAssert FlatType isnot T  # avoid infinite recursion
     verifySerializable(FlatType)
   elif FlatType is int | uint:
-    {.
-      fatal:
-        $T &
-        ": Serializing a number requires specifying the amount of bits via the type."
-    .}
+    {.fatal: $T & ": Serializing a number requires specifying the amount of bits via the type.".}
   elif FlatType is seq:
     when FlatType isnot seq[byte]:
       when defined(ConformanceTest):
@@ -219,30 +195,27 @@ func verifySerializable*[T](ty: typedesc[T]) {.compileTime.} =
       {.fatal: $T & ": missing {.proto2.} or {.proto3.}".}
 
     enumInstanceSerializedFields(inst, fieldName, fieldVar):
-      when isProto2 and not T.isRequired(fieldName) and fieldVar isnot (seq or PBOption) and
+      when isProto2 and not T.isRequired(fieldName) and
+          fieldVar isnot (seq or PBOption) and
           not isExtension(Protobuf, typeof(fieldVar)):
-        fieldError T,
-          fieldName,
-          "proto2 requires every field to either have the required pragma attached or be a repeated field/PBOption."
+        fieldError T, fieldName, "proto2 requires every field to either have the required pragma attached or be a repeated field/PBOption."
       when isProto3 and (
-        T.hasCustomPragmaFixed(fieldName, required) or fieldVar is PBOption or
+        T.hasCustomPragmaFixed(fieldName, required) or
+        fieldVar is PBOption or
         isExtension(Protobuf, typeof(fieldVar))
       ):
-        fieldError T,
-          fieldName, "The required pragma/PBOption type can only be used with proto2."
+        fieldError T, fieldName, "The required pragma/PBOption type can only be used with proto2."
 
-      protoType(ProtoType {.used.}, T, typeof(fieldVar), fieldName)
-        # Ensure we can form a ProtoType
+      protoType(ProtoType {.used.}, T, typeof(fieldVar), fieldName) # Ensure we can form a ProtoType
 
       const fieldNum = T.fieldNumberOf(fieldName)
       when not validFieldNumber(fieldNum, strict = true):
         fieldError T, fieldName, "Field numbers must be in the range [1..2^29-1]"
 
       if fieldNumberSet.containsOrIncl(fieldNum):
-        raiseAssert $T & "." & fieldName &
-          ": Field number was used twice on two different fields: " & $fieldNum
+        raiseAssert $T & "." & fieldName & ": Field number was used twice on two different fields: " & $fieldNum
 
       when T.hasCustomPragmaFixed(fieldName, ext):
-        discard # do nothing for extensions; they should validate on read/write
+        discard  # do nothing for extensions; they should validate on read/write
       else:
         verifySerializable(typeof(fieldVar))

--- a/protobuf_serialization/internal.nim
+++ b/protobuf_serialization/internal.nim
@@ -100,6 +100,33 @@ macro setOneof*(
   quote do:
     `fieldVar` = typeof(`fieldVar`)(`kind`: `kVal`, `field`: move(`fVal`))
 
+macro oneofCaseOf*(T: type, value, fVar, fName, body: untyped): untyped =
+  result = newStmtList()
+  var caseStmt = newSeq[NimNode]()
+  let typeImpl = getType(T)[1].getImpl()
+  var enumTyp: NimNode = nil
+  for field in recordFields(typeImpl):
+    if field.caseField == nil:
+      doAssert enumTyp == nil
+      enumTyp = field.typ
+      caseStmt.add newDotExpr(value, ident($field.name.skipPragma))
+    else:
+      doAssert enumTyp != nil
+      let branchVal = field.caseBranch[0]
+      let fieldName = newLit($field.name.skipPragma)
+      let fieldVal = newDotExpr(value, ident($field.name.skipPragma))
+      let body2 = quote do:
+        const `fName` = `fieldName`
+        template `fVar`(): untyped =
+          `fieldVal`
+        `body`
+      caseStmt.add newTree(nnkOfBranch, branchVal, body2)
+  doAssert caseStmt.len > 0
+  let defVal = quote do: default(typeof(`enumTyp`))
+  let discardStmt = quote do: discard
+  caseStmt.add newTree(nnkOfBranch, defVal, discardStmt)
+  result.add newTree(nnkCaseStmt, caseStmt)
+
 template protoType*(InnerType, RootType, FieldType: untyped, fieldName: untyped) =
   mixin flatType, isExtension
 

--- a/protobuf_serialization/reader.nim
+++ b/protobuf_serialization/reader.nim
@@ -13,25 +13,29 @@ import
 
 export inputs, serialization, codec, types
 
-proc readValueInternal[T: object](
-  stream: InputStream, value: var T, silent: bool = false
-) {.raises: [SerializationError, IOError].}
+proc readValueInternal[T: object](stream: InputStream, value: var T, silent: bool = false) {.raises: [SerializationError, IOError].}
 
 proc readFieldInto*[T: not seq and not PBOption](
-    stream: InputStream, value: var T, header: FieldHeader, ProtoType: type ProtobufExt
+  stream: InputStream,
+  value: var T,
+  header: FieldHeader,
+  ProtoType: type ProtobufExt
 ): bool {.raises: [SerializationError, IOError].} =
   unsupportedProtoType ProtoType.FieldType, ProtoType.RootType, ProtoType.fieldName
 
 proc readFieldPackedInto*[T](
-    stream: InputStream, value: var T, header: FieldHeader, ProtoType: type ProtobufExt
+  stream: InputStream,
+  value: var T,
+  header: FieldHeader,
+  ProtoType: type ProtobufExt
 ): bool {.raises: [SerializationError, IOError].} =
   unsupportedProtoType ProtoType.FieldType, ProtoType.RootType, ProtoType.fieldName
 
 proc readFieldInto*[T: not PBOption](
-    stream: InputStream,
-    value: var seq[T],
-    header: FieldHeader,
-    ProtoType: type ProtobufExt,
+  stream: InputStream,
+  value: var seq[T],
+  header: FieldHeader,
+  ProtoType: type ProtobufExt
 ): bool {.raises: [SerializationError, IOError], deprecated: "use extensionDefaults".} =
   var val = default(typeof(value[0]))
   if stream.readFieldInto(val, header, ProtoType):
@@ -49,7 +53,10 @@ when not declared(newSeqUninit):
       newSeq[T](len)
 
 proc readFieldInto*[T: object and not PBOption](
-    stream: InputStream, value: var T, header: FieldHeader, ProtoType: type pbytes
+  stream: InputStream,
+  value: var T,
+  header: FieldHeader,
+  ProtoType: type pbytes
 ): bool {.raises: [SerializationError, IOError].} =
   if header.kind() == wireKind(ProtoType):
     let len = stream.readLength()
@@ -72,7 +79,10 @@ proc readFieldInto*[T: object and not PBOption](
     false
 
 proc readFieldInto*[T: not object and (seq[byte] or not seq)](
-    stream: InputStream, value: var T, header: FieldHeader, ProtoType: type SomeProto
+  stream: InputStream,
+  value: var T,
+  header: FieldHeader,
+  ProtoType: type SomeProto
 ): bool {.raises: [SerializationError, IOError].} =
   if header.kind() == wireKind(ProtoType):
     assign(value, T(stream.readValue(ProtoType)))
@@ -81,10 +91,10 @@ proc readFieldInto*[T: not object and (seq[byte] or not seq)](
     false
 
 proc readFieldInto*[T: not byte](
-    stream: InputStream,
-    value: var seq[T],
-    header: FieldHeader,
-    ProtoType: type SomeProto,
+  stream: InputStream,
+  value: var seq[T],
+  header: FieldHeader,
+  ProtoType: type SomeProto
 ): bool {.raises: [SerializationError, IOError].} =
   var val = default(T)
   if stream.readFieldInto(val, header, ProtoType):
@@ -94,7 +104,10 @@ proc readFieldInto*[T: not byte](
     false
 
 proc readFieldInto*(
-    stream: InputStream, value: var PBOption, header: FieldHeader, ProtoType: type
+  stream: InputStream,
+  value: var PBOption,
+  header: FieldHeader,
+  ProtoType: type
 ): bool {.raises: [SerializationError, IOError].} =
   var val: typeof(value.get())
   if stream.readFieldInto(val, header, ProtoType):
@@ -104,10 +117,10 @@ proc readFieldInto*(
     false
 
 proc readFieldPackedInto*[T: not byte](
-    stream: InputStream,
-    value: var seq[T],
-    header: FieldHeader,
-    ProtoType: type SomePrimitive,
+  stream: InputStream,
+  value: var seq[T],
+  header: FieldHeader,
+  ProtoType: type SomePrimitive
 ): bool {.raises: [SerializationError, IOError].} =
   # TODO make more efficient
   doAssert header.kind() == WireKind.LengthDelim
@@ -121,12 +134,11 @@ proc readFieldPackedInto*[T: not byte](
     doAssert r
   true
 
-proc readValueInternal[T: object](
-    stream: InputStream, value: var T, silent: bool = false
-) {.raises: [SerializationError, IOError].} =
+proc readValueInternal[T: object](stream: InputStream, value: var T, silent: bool = false) {.raises: [SerializationError, IOError].} =
   mixin supportsPacked, readFieldPackedInto
 
-  const isProto2: bool = T.isProto2()
+  const
+    isProto2: bool = T.isProto2()
 
   when isProto2:
     var requiredSets: HashSet[int]
@@ -168,8 +180,7 @@ proc readValueInternal[T: object](
             stream.readFieldInto(fieldVar, header, ProtoType)
 
         when isProto2:
-          if not silent and knownField:
-            requiredSets.excl i
+          if not silent and knownField: requiredSets.excl i
 
     if knownField:
       for fieldName, fieldVar in fieldPairs(value):
@@ -182,27 +193,20 @@ proc readValueInternal[T: object](
                 resetOneof(value, enumValue)
 
     if not knownField and pos == stream.pos():
-      case header.kind()
-      of WireKind.Varint:
-        stream.skipValue(puint64)
-      of WireKind.Fixed64:
-        stream.skipValue(fixed64)
-      of WireKind.LengthDelim:
-        stream.skipValue(pbytes)
-      of WireKind.Fixed32:
-        stream.skipValue(fixed32)
+      case header.kind():
+      of WireKind.Varint: stream.skipValue(puint64)
+      of WireKind.Fixed64: stream.skipValue(fixed64)
+      of WireKind.LengthDelim: stream.skipValue(pbytes)
+      of WireKind.Fixed32: stream.skipValue(fixed32)
 
   when isProto2:
     if (requiredSets.len != 0):
       raise newException(
-        ProtobufReadError, "Message didn't encode a required field: " & $requiredSets
-      )
+        ProtobufReadError,
+        "Message didn't encode a required field: " & $requiredSets)
 
-proc readValue*[T: object](
-    reader: ProtobufReader, value: var T
-) {.raises: [SerializationError, IOError].} =
-  static:
-    verifySerializable(T)
+proc readValue*[T: object](reader: ProtobufReader, value: var T) {.raises: [SerializationError, IOError].} =
+  static: verifySerializable(T)
 
   # TODO skip length header
   try:

--- a/protobuf_serialization/reader.nim
+++ b/protobuf_serialization/reader.nim
@@ -162,38 +162,34 @@ proc readValueInternal[T: object](stream: InputStream, value: var T, silent: boo
 
     enumInstanceSerializedFields(value, fieldName, fieldVar):
       inc i
-      when isOneof(fieldVar):
-        # For repeated, and in general need to create a flat type out of fieldVar
-        # set values before returning from readValueInternal but that wont work either
-        # when the seq is in a nested message
-        enumOneofFields(fieldVar, kind, fieldName2, fieldVar2):
-          const fieldNum = typeof(fieldVar).fieldNumberOf(fieldName2)
+      when T.isOneof(fieldName):
+        enumOneofFields(typeof(fieldVar), kName, kVal, fName, fTyp):
+          const fieldNum = typeof(fieldVar).fieldNumberOf(fName)
           if headerNum == fieldNum:
-            var value = default(typeof(fieldVar2))
-            protoType(ProtoType, typeof(fieldVar), typeof(fieldVar2), fieldName2)
+            var value = default(fTyp)
+            protoType(ProtoType, typeof(fieldVar), fTyp, fName)
             knownField = stream.readFieldInto(value, header, ProtoType)
             if knownField:
-              fieldVar = typeof(fieldVar)(kind: discriminator)
-              fieldVar2 = move(value)
-              setOneof(fieldVar, kind, value)
+              setOneof(fieldVar, kName, kVal, fName, value)
       else:
         const fieldNum = T.fieldNumberOf(fieldName)
         if headerNum == fieldNum:
           protoType(ProtoType, T, typeof(fieldVar), fieldName)
-          knownField = stream.readFieldInto(fieldVar, header, ProtoType)
+          # TODO should we allow reading packed fields into non-repeated fields?
+          knownField =
+            when supportsPacked(typeof(fieldVar), ProtoType):
+              if header.kind() == WireKind.LengthDelim:
+                stream.readFieldPackedInto(fieldVar, header, ProtoType)
+              else:
+                stream.readFieldInto(fieldVar, header, ProtoType)
+            elif typeof(fieldVar) is ref and defined(ConformanceTest):
+              fieldVar = new typeof(fieldVar)
+              stream.readFieldInto(fieldVar[], header, ProtoType)
+            else:
+              stream.readFieldInto(fieldVar, header, ProtoType)
 
           when isProto2:
             if not silent and knownField: requiredSets.excl i
-
-    if knownField:
-      for fieldName, fieldVar in fieldPairs(value):
-        when T.isOneof(fieldName):
-          enumEnumValues(typeof(fieldVar), enumValue):
-            when ord(enumValue) != 0:
-              const fieldNum = T.fieldNumberOf($enumValue)
-              if headerNum == fieldNum:
-                fieldVar = enumValue
-                resetOneof(value, enumValue)
 
     if not knownField and pos == stream.pos():
       case header.kind():

--- a/protobuf_serialization/reader.nim
+++ b/protobuf_serialization/reader.nim
@@ -162,25 +162,26 @@ proc readValueInternal[T: object](stream: InputStream, value: var T, silent: boo
 
     enumInstanceSerializedFields(value, fieldName, fieldVar):
       inc i
-      const fieldNum = T.fieldNumberOf(fieldName)
+      when isOneof(fieldVar):
+        enumOneofFields(fieldVar, kind, fieldName2, fieldVar2):
+          const fieldNum = typeof(fieldVar).fieldNumberOf(fieldName2)
+          if headerNum == fieldNum:
+            var value = default(typeof(fieldVar2))
+            protoType(ProtoType, typeof(fieldVar), typeof(fieldVar2), fieldName2)
+            knownField = stream.readFieldInto(value, header, ProtoType)
+            if knownField:
+              fieldVar = typeof(fieldVar)(kind: discriminator)
+              fieldVar2 = move(value)
+              setOneof(fieldVar, kind, value)
+      else:
+        const fieldNum = T.fieldNumberOf(fieldName)
+        if headerNum == fieldNum:
+          protoType(ProtoType, T, typeof(fieldVar), fieldName)
+          # TODO should we allow reading packed fields into non-repeated fields?
+          knownField = stream.readFieldInto(fieldVar, header, ProtoType)
 
-      if headerNum == fieldNum:
-        protoType(ProtoType, T, typeof(fieldVar), fieldName)
-        # TODO should we allow reading packed fields into non-repeated fields?
-        knownField =
-          when supportsPacked(typeof(fieldVar), ProtoType):
-            if header.kind() == WireKind.LengthDelim:
-              stream.readFieldPackedInto(fieldVar, header, ProtoType)
-            else:
-              stream.readFieldInto(fieldVar, header, ProtoType)
-          elif typeof(fieldVar) is ref and defined(ConformanceTest):
-            fieldVar = new typeof(fieldVar)
-            stream.readFieldInto(fieldVar[], header, ProtoType)
-          else:
-            stream.readFieldInto(fieldVar, header, ProtoType)
-
-        when isProto2:
-          if not silent and knownField: requiredSets.excl i
+          when isProto2:
+            if not silent and knownField: requiredSets.excl i
 
     if knownField:
       for fieldName, fieldVar in fieldPairs(value):

--- a/protobuf_serialization/reader.nim
+++ b/protobuf_serialization/reader.nim
@@ -167,9 +167,9 @@ proc readValueInternal[T: object](stream: InputStream, value: var T, silent: boo
           const fieldNum = typeof(fieldVal).fieldNumberOf(fName)
           if headerNum == fieldNum:
             protoType(ProtoType, typeof(fieldVal), fTyp, fName)
-            knownField = case oneofVar(fieldVal, kName)
+            knownField = case fieldVal.field(kName)
             of kVal:
-              stream.readFieldInto(oneofVar(fieldVal, fName), header, ProtoType)
+              stream.readFieldInto(fieldVal.field(fName), header, ProtoType)
             else:
               var val = default(fTyp)
               if stream.readFieldInto(val, header, ProtoType):

--- a/protobuf_serialization/reader.nim
+++ b/protobuf_serialization/reader.nim
@@ -152,19 +152,20 @@ proc readValueInternal[T: object](stream: InputStream, value: var T, silent: boo
 
   while stream.readable():
     let header = stream.readHeader()
+    let headerNum = header.number()
     let pos = stream.pos()
     var i {.used.} = -1
     var knownField = false
 
-    if not header.number().validFieldNumber(true):
-      raise newException(ProtobufReadError, "Invalid field number: " & $header.number())
+    if not headerNum.validFieldNumber(true):
+      raise newException(ProtobufReadError, "Invalid field number: " & $headerNum)
 
     enumInstanceSerializedFields(value, fieldName, fieldVar):
       inc i
       const
         fieldNum = T.fieldNumberOf(fieldName)
 
-      if header.number() == fieldNum:
+      if headerNum == fieldNum:
         protoType(ProtoType, T, typeof(fieldVar), fieldName)
         # TODO should we allow reading packed fields into non-repeated fields?
         knownField =

--- a/protobuf_serialization/reader.nim
+++ b/protobuf_serialization/reader.nim
@@ -166,11 +166,17 @@ proc readValueInternal[T: object](stream: InputStream, value: var T, silent: boo
         enumOneofFields(typeof(fieldVal), kName, kVal, fName, fTyp):
           const fieldNum = typeof(fieldVal).fieldNumberOf(fName)
           if headerNum == fieldNum:
-            var val = default(fTyp)
             protoType(ProtoType, typeof(fieldVal), fTyp, fName)
-            knownField = stream.readFieldInto(val, header, ProtoType)
-            if knownField:
-              setOneof(fieldVal, kName, kVal, fName, val)
+            knownField = case oneofVar(fieldVal, kName)
+            of kVal:
+              stream.readFieldInto(oneofVar(fieldVal, fName), header, ProtoType)
+            else:
+              var val = default(fTyp)
+              if stream.readFieldInto(val, header, ProtoType):
+                setOneof(fieldVal, kName, kVal, fName, val)
+                true
+              else:
+                false
       else:
         const fieldNum = T.fieldNumberOf(fieldName)
         if headerNum == fieldNum:
@@ -183,7 +189,8 @@ proc readValueInternal[T: object](stream: InputStream, value: var T, silent: boo
               else:
                 stream.readFieldInto(fieldVal, header, ProtoType)
             elif typeof(fieldVal) is ref and defined(ConformanceTest):
-              fieldVal = new typeof(fieldVal)
+              if fieldVal.isNil:
+                fieldVal = new typeof(fieldVal)
               stream.readFieldInto(fieldVal[], header, ProtoType)
             else:
               stream.readFieldInto(fieldVal, header, ProtoType)

--- a/protobuf_serialization/reader.nim
+++ b/protobuf_serialization/reader.nim
@@ -13,29 +13,25 @@ import
 
 export inputs, serialization, codec, types
 
-proc readValueInternal[T: object](stream: InputStream, value: var T, silent: bool = false) {.raises: [SerializationError, IOError].}
+proc readValueInternal[T: object](
+  stream: InputStream, value: var T, silent: bool = false
+) {.raises: [SerializationError, IOError].}
 
 proc readFieldInto*[T: not seq and not PBOption](
-  stream: InputStream,
-  value: var T,
-  header: FieldHeader,
-  ProtoType: type ProtobufExt
+    stream: InputStream, value: var T, header: FieldHeader, ProtoType: type ProtobufExt
 ): bool {.raises: [SerializationError, IOError].} =
   unsupportedProtoType ProtoType.FieldType, ProtoType.RootType, ProtoType.fieldName
 
 proc readFieldPackedInto*[T](
-  stream: InputStream,
-  value: var T,
-  header: FieldHeader,
-  ProtoType: type ProtobufExt
+    stream: InputStream, value: var T, header: FieldHeader, ProtoType: type ProtobufExt
 ): bool {.raises: [SerializationError, IOError].} =
   unsupportedProtoType ProtoType.FieldType, ProtoType.RootType, ProtoType.fieldName
 
 proc readFieldInto*[T: not PBOption](
-  stream: InputStream,
-  value: var seq[T],
-  header: FieldHeader,
-  ProtoType: type ProtobufExt
+    stream: InputStream,
+    value: var seq[T],
+    header: FieldHeader,
+    ProtoType: type ProtobufExt,
 ): bool {.raises: [SerializationError, IOError], deprecated: "use extensionDefaults".} =
   var val = default(typeof(value[0]))
   if stream.readFieldInto(val, header, ProtoType):
@@ -53,10 +49,7 @@ when not declared(newSeqUninit):
       newSeq[T](len)
 
 proc readFieldInto*[T: object and not PBOption](
-  stream: InputStream,
-  value: var T,
-  header: FieldHeader,
-  ProtoType: type pbytes
+    stream: InputStream, value: var T, header: FieldHeader, ProtoType: type pbytes
 ): bool {.raises: [SerializationError, IOError].} =
   if header.kind() == wireKind(ProtoType):
     let len = stream.readLength()
@@ -79,10 +72,7 @@ proc readFieldInto*[T: object and not PBOption](
     false
 
 proc readFieldInto*[T: not object and (seq[byte] or not seq)](
-  stream: InputStream,
-  value: var T,
-  header: FieldHeader,
-  ProtoType: type SomeProto
+    stream: InputStream, value: var T, header: FieldHeader, ProtoType: type SomeProto
 ): bool {.raises: [SerializationError, IOError].} =
   if header.kind() == wireKind(ProtoType):
     assign(value, T(stream.readValue(ProtoType)))
@@ -91,10 +81,10 @@ proc readFieldInto*[T: not object and (seq[byte] or not seq)](
     false
 
 proc readFieldInto*[T: not byte](
-  stream: InputStream,
-  value: var seq[T],
-  header: FieldHeader,
-  ProtoType: type SomeProto
+    stream: InputStream,
+    value: var seq[T],
+    header: FieldHeader,
+    ProtoType: type SomeProto,
 ): bool {.raises: [SerializationError, IOError].} =
   var val = default(T)
   if stream.readFieldInto(val, header, ProtoType):
@@ -104,10 +94,7 @@ proc readFieldInto*[T: not byte](
     false
 
 proc readFieldInto*(
-  stream: InputStream,
-  value: var PBOption,
-  header: FieldHeader,
-  ProtoType: type
+    stream: InputStream, value: var PBOption, header: FieldHeader, ProtoType: type
 ): bool {.raises: [SerializationError, IOError].} =
   var val: typeof(value.get())
   if stream.readFieldInto(val, header, ProtoType):
@@ -117,10 +104,10 @@ proc readFieldInto*(
     false
 
 proc readFieldPackedInto*[T: not byte](
-  stream: InputStream,
-  value: var seq[T],
-  header: FieldHeader,
-  ProtoType: type SomePrimitive
+    stream: InputStream,
+    value: var seq[T],
+    header: FieldHeader,
+    ProtoType: type SomePrimitive,
 ): bool {.raises: [SerializationError, IOError].} =
   # TODO make more efficient
   doAssert header.kind() == WireKind.LengthDelim
@@ -134,11 +121,12 @@ proc readFieldPackedInto*[T: not byte](
     doAssert r
   true
 
-proc readValueInternal[T: object](stream: InputStream, value: var T, silent: bool = false) {.raises: [SerializationError, IOError].} =
+proc readValueInternal[T: object](
+    stream: InputStream, value: var T, silent: bool = false
+) {.raises: [SerializationError, IOError].} =
   mixin supportsPacked, readFieldPackedInto
 
-  const
-    isProto2: bool = T.isProto2()
+  const isProto2: bool = T.isProto2()
 
   when isProto2:
     var requiredSets: HashSet[int]
@@ -162,8 +150,7 @@ proc readValueInternal[T: object](stream: InputStream, value: var T, silent: boo
 
     enumInstanceSerializedFields(value, fieldName, fieldVar):
       inc i
-      const
-        fieldNum = T.fieldNumberOf(fieldName)
+      const fieldNum = T.fieldNumberOf(fieldName)
 
       if headerNum == fieldNum:
         protoType(ProtoType, T, typeof(fieldVar), fieldName)
@@ -181,23 +168,41 @@ proc readValueInternal[T: object](stream: InputStream, value: var T, silent: boo
             stream.readFieldInto(fieldVar, header, ProtoType)
 
         when isProto2:
-          if not silent and knownField: requiredSets.excl i
+          if not silent and knownField:
+            requiredSets.excl i
+
+    if knownField:
+      for fieldName, fieldVar in fieldPairs(value):
+        when T.isOneof(fieldName):
+          enumEnumValues(typeof(fieldVar), enumValue):
+            when ord(enumValue) != 0:
+              const fieldNum = T.fieldNumberOf($enumValue)
+              if headerNum == fieldNum:
+                fieldVar = enumValue
+                resetOneof(value, enumValue)
 
     if not knownField and pos == stream.pos():
-      case header.kind():
-      of WireKind.Varint: stream.skipValue(puint64)
-      of WireKind.Fixed64: stream.skipValue(fixed64)
-      of WireKind.LengthDelim: stream.skipValue(pbytes)
-      of WireKind.Fixed32: stream.skipValue(fixed32)
+      case header.kind()
+      of WireKind.Varint:
+        stream.skipValue(puint64)
+      of WireKind.Fixed64:
+        stream.skipValue(fixed64)
+      of WireKind.LengthDelim:
+        stream.skipValue(pbytes)
+      of WireKind.Fixed32:
+        stream.skipValue(fixed32)
 
   when isProto2:
     if (requiredSets.len != 0):
       raise newException(
-        ProtobufReadError,
-        "Message didn't encode a required field: " & $requiredSets)
+        ProtobufReadError, "Message didn't encode a required field: " & $requiredSets
+      )
 
-proc readValue*[T: object](reader: ProtobufReader, value: var T) {.raises: [SerializationError, IOError].} =
-  static: verifySerializable(T)
+proc readValue*[T: object](
+    reader: ProtobufReader, value: var T
+) {.raises: [SerializationError, IOError].} =
+  static:
+    verifySerializable(T)
 
   # TODO skip length header
   try:

--- a/protobuf_serialization/reader.nim
+++ b/protobuf_serialization/reader.nim
@@ -166,11 +166,11 @@ proc readValueInternal[T: object](stream: InputStream, value: var T, silent: boo
         enumOneofFields(typeof(fieldVar), kName, kVal, fName, fTyp):
           const fieldNum = typeof(fieldVar).fieldNumberOf(fName)
           if headerNum == fieldNum:
-            var value = default(fTyp)
+            var val = default(fTyp)
             protoType(ProtoType, typeof(fieldVar), fTyp, fName)
-            knownField = stream.readFieldInto(value, header, ProtoType)
+            knownField = stream.readFieldInto(val, header, ProtoType)
             if knownField:
-              setOneof(fieldVar, kName, kVal, fName, value)
+              setOneof(fieldVar, kName, kVal, fName, val)
       else:
         const fieldNum = T.fieldNumberOf(fieldName)
         if headerNum == fieldNum:

--- a/protobuf_serialization/reader.nim
+++ b/protobuf_serialization/reader.nim
@@ -160,33 +160,33 @@ proc readValueInternal[T: object](stream: InputStream, value: var T, silent: boo
     if not headerNum.validFieldNumber(true):
       raise newException(ProtobufReadError, "Invalid field number: " & $headerNum)
 
-    enumInstanceSerializedFields(value, fieldName, fieldVar):
+    enumInstanceSerializedFields(value, fieldName, fieldVal):
       inc i
       when T.isOneof(fieldName):
-        enumOneofFields(typeof(fieldVar), kName, kVal, fName, fTyp):
-          const fieldNum = typeof(fieldVar).fieldNumberOf(fName)
+        enumOneofFields(typeof(fieldVal), kName, kVal, fName, fTyp):
+          const fieldNum = typeof(fieldVal).fieldNumberOf(fName)
           if headerNum == fieldNum:
             var val = default(fTyp)
-            protoType(ProtoType, typeof(fieldVar), fTyp, fName)
+            protoType(ProtoType, typeof(fieldVal), fTyp, fName)
             knownField = stream.readFieldInto(val, header, ProtoType)
             if knownField:
-              setOneof(fieldVar, kName, kVal, fName, val)
+              setOneof(fieldVal, kName, kVal, fName, val)
       else:
         const fieldNum = T.fieldNumberOf(fieldName)
         if headerNum == fieldNum:
-          protoType(ProtoType, T, typeof(fieldVar), fieldName)
+          protoType(ProtoType, T, typeof(fieldVal), fieldName)
           # TODO should we allow reading packed fields into non-repeated fields?
           knownField =
-            when supportsPacked(typeof(fieldVar), ProtoType):
+            when supportsPacked(typeof(fieldVal), ProtoType):
               if header.kind() == WireKind.LengthDelim:
-                stream.readFieldPackedInto(fieldVar, header, ProtoType)
+                stream.readFieldPackedInto(fieldVal, header, ProtoType)
               else:
-                stream.readFieldInto(fieldVar, header, ProtoType)
-            elif typeof(fieldVar) is ref and defined(ConformanceTest):
-              fieldVar = new typeof(fieldVar)
-              stream.readFieldInto(fieldVar[], header, ProtoType)
+                stream.readFieldInto(fieldVal, header, ProtoType)
+            elif typeof(fieldVal) is ref and defined(ConformanceTest):
+              fieldVal = new typeof(fieldVal)
+              stream.readFieldInto(fieldVal[], header, ProtoType)
             else:
-              stream.readFieldInto(fieldVar, header, ProtoType)
+              stream.readFieldInto(fieldVal, header, ProtoType)
 
           when isProto2:
             if not silent and knownField: requiredSets.excl i

--- a/protobuf_serialization/reader.nim
+++ b/protobuf_serialization/reader.nim
@@ -163,6 +163,9 @@ proc readValueInternal[T: object](stream: InputStream, value: var T, silent: boo
     enumInstanceSerializedFields(value, fieldName, fieldVar):
       inc i
       when isOneof(fieldVar):
+        # For repeated, and in general need to create a flat type out of fieldVar
+        # set values before returning from readValueInternal but that wont work either
+        # when the seq is in a nested message
         enumOneofFields(fieldVar, kind, fieldName2, fieldVar2):
           const fieldNum = typeof(fieldVar).fieldNumberOf(fieldName2)
           if headerNum == fieldNum:
@@ -177,7 +180,6 @@ proc readValueInternal[T: object](stream: InputStream, value: var T, silent: boo
         const fieldNum = T.fieldNumberOf(fieldName)
         if headerNum == fieldNum:
           protoType(ProtoType, T, typeof(fieldVar), fieldName)
-          # TODO should we allow reading packed fields into non-repeated fields?
           knownField = stream.readFieldInto(fieldVar, header, ProtoType)
 
           when isProto2:

--- a/protobuf_serialization/sizer.nim
+++ b/protobuf_serialization/sizer.nim
@@ -117,17 +117,22 @@ func computeObjectSize*[T: object](value: T): int =
 
   var total = 0
   enumInstanceSerializedFields(value, fieldName, fieldVal):
-    const
-      fieldNum = T.fieldNumberOf(fieldName)
-      isPacked = T.isPacked(fieldName).get(isProto3)
-
-    protoType(ProtoType, T, typeof(fieldVal), fieldName)
-
-    let fieldSize =
-      when isPacked and supportsPacked(typeof(fieldVal), ProtoType):
-        computeFieldSizePacked(fieldNum, fieldVal, ProtoType)
-      else:
-        computeFieldSize(fieldNum, fieldVal, ProtoType, isProto3)
+    var fieldSize = 0
+    when T.isOneof(fieldName):
+      oneofCaseOf(typeof(fieldVal), fieldVal, fVal, fName):
+        const fieldNum = typeof(fieldVal).fieldNumberOf(fName)
+        protoType(ProtoType, typeof(fieldVal), typeof(fVal), fName)
+        fieldSize = computeFieldSize(fieldNum, fVal, ProtoType, false)
+    else:
+      const
+        fieldNum = T.fieldNumberOf(fieldName)
+        isPacked = T.isPacked(fieldName).get(isProto3)
+      protoType(ProtoType, T, typeof(fieldVal), fieldName)
+      fieldSize =
+        when isPacked and supportsPacked(typeof(fieldVal), ProtoType):
+          computeFieldSizePacked(fieldNum, fieldVal, ProtoType)
+        else:
+          computeFieldSize(fieldNum, fieldVal, ProtoType, isProto3)
 
     total += fieldSize
 

--- a/protobuf_serialization/types.nim
+++ b/protobuf_serialization/types.nim
@@ -46,6 +46,7 @@ template pint*() {.pragma.} # encode as `intXX`
 template sint*() {.pragma.} # encode as `sintXX`
 template fixed*() {.pragma.} # encode as `fixedXX`
 template ext*() {.pragma.}
+template oneof*() {.pragma.}
 
 func init*(
   T: type ProtobufWriter,

--- a/protobuf_serialization/writer.nim
+++ b/protobuf_serialization/writer.nim
@@ -108,19 +108,23 @@ proc writeObject[T: object](stream: OutputStream, value: T) {.raises: [IOError].
   static: doAssert isProto2 xor isProto3
 
   enumInstanceSerializedFields(value, fieldName, fieldVal):
-    const
-      fieldNum = T.fieldNumberOf(fieldName)
-      isPacked = T.isPacked(fieldName).get(isProto3)
-
-    protoType(ProtoType, T, typeof(fieldVal), fieldName)
-
-    when isPacked and supportsPacked(typeof(fieldVal), ProtoType):
-      stream.writeFieldPacked(fieldNum, fieldVal, ProtoType)
-    elif typeof(fieldVal) is ref and defined(ConformanceTest):
-      if not fieldVal.isNil():
-        stream.writeField(fieldNum, fieldVal[], ProtoType)
+    when T.isOneof(fieldName):
+      oneofCaseOf(typeof(fieldVal), fieldVal, fVal, fName):
+        const fieldNum = typeof(fieldVal).fieldNumberOf(fName)
+        protoType(ProtoType, typeof(fieldVal), typeof(fVal), fName)
+        stream.writeField(fieldNum, fVal, ProtoType, false)
     else:
-      stream.writeField(fieldNum, fieldVal, ProtoType, isProto3)
+      const
+        fieldNum = T.fieldNumberOf(fieldName)
+        isPacked = T.isPacked(fieldName).get(isProto3)
+      protoType(ProtoType, T, typeof(fieldVal), fieldName)
+      when isPacked and supportsPacked(typeof(fieldVal), ProtoType):
+        stream.writeFieldPacked(fieldNum, fieldVal, ProtoType)
+      elif typeof(fieldVal) is ref and defined(ConformanceTest):
+        if not fieldVal.isNil():
+          stream.writeField(fieldNum, fieldVal[], ProtoType)
+      else:
+        stream.writeField(fieldNum, fieldVal, ProtoType, isProto3)
 
 proc writeValue*[T: object](writer: ProtobufWriter, value: T) {.raises: [IOError].} =
   static: verifySerializable(T)

--- a/tests/conformance/conformance_nim.nim
+++ b/tests/conformance/conformance_nim.nim
@@ -33,24 +33,24 @@ template processPayload(payload, DecodeType): untyped =
   try:
     let x = Protobuf.decode(payload, DecodeType)
     try:
-      ConformanceResponse(protobuf_payload: Protobuf.encode(x))
+      ConformanceResponse(result: Result(kind: ResultKind.protobuf_payload, protobuf_payload: Protobuf.encode(x)))
     except ProtobufError as exc:
-      ConformanceResponse(serialize_error: "serialize_error: " & exc.msg)
+      ConformanceResponse(result: Result(kind: ResultKind.serialize_error, serialize_error: "serialize_error: " & exc.msg))
   #except ProtobufGroupError as exc:
   #  ConformanceResponse(skipped: "skipped: " & exc.msg)
   except ProtobufError as exc:
-    ConformanceResponse(parse_error: "parse_error: " & exc.msg)
+      ConformanceResponse(result: Result(kind: ResultKind.parse_error, parse_error: "parse_error: " & exc.msg))
 
 proc doTest(request: ConformanceRequest): ConformanceResponse =
   if request.requested_output_format != WireFormat.PROTOBUF or
-      request.protobuf_payload.len() == 0:
-    ConformanceResponse(skipped: "skip not protobuf")
+      request.payload.kind != PayloadKind.protobuf_payload:
+    ConformanceResponse(result: Result(kind: ResultKind.skipped, skipped: "skip not protobuf"))
   elif request.message_type == "protobuf_test_messages.proto3.TestAllTypesProto3":
-    processPayload(request.protobuf_payload, TestAllTypesProto3)
+    processPayload(request.payload.protobuf_payload, TestAllTypesProto3)
   elif request.message_type == "protobuf_test_messages.proto2.TestAllTypesProto2":
-    processPayload(request.protobuf_payload, TestAllTypesProto2)
+    processPayload(request.payload.protobuf_payload, TestAllTypesProto2)
   else:
-    ConformanceResponse(skipped: "skip unknown message type: " & request.message_type)
+    ConformanceResponse(result: Result(kind: ResultKind.skipped, skipped: "skip unknown message type: " & request.message_type))
 
 proc doTest(): bool =
   let length =
@@ -63,12 +63,7 @@ proc doTest(): bool =
 
   let request = Protobuf.decode(serializedRequest, ConformanceRequest)
   let response = doTest(request)
-  let serializedResponse = if response == default(ConformanceResponse):
-    # XXX: remove once oneof is supported;
-    #      this is field 3 set to an empty seq
-    "1a00".hexToSeqByte
-  else:
-    Protobuf.encode(response)
+  let serializedResponse = Protobuf.encode(response)
 
   writeIntLE(serializedResponse.len().int32)
 

--- a/tests/conformance/conformance_nim.nim
+++ b/tests/conformance/conformance_nim.nim
@@ -33,24 +33,49 @@ template processPayload(payload, DecodeType): untyped =
   try:
     let x = Protobuf.decode(payload, DecodeType)
     try:
-      ConformanceResponse(result: Result(kind: ResultKind.protobuf_payload, protobuf_payload: Protobuf.encode(x)))
+      ConformanceResponse(
+        result: ConformanceResponseResult(
+          kind: ConformanceResponseResultKind.protobuf_payload,
+          protobuf_payload: Protobuf.encode(x)
+        )
+      )
     except ProtobufError as exc:
-      ConformanceResponse(result: Result(kind: ResultKind.serialize_error, serialize_error: "serialize_error: " & exc.msg))
+      ConformanceResponse(
+        result: ConformanceResponseResult(
+          kind: ConformanceResponseResultKind.serialize_error,
+          serialize_error: "serialize_error: " & exc.msg
+        )
+      )
   #except ProtobufGroupError as exc:
   #  ConformanceResponse(skipped: "skipped: " & exc.msg)
   except ProtobufError as exc:
-      ConformanceResponse(result: Result(kind: ResultKind.parse_error, parse_error: "parse_error: " & exc.msg))
+      ConformanceResponse(
+        result: ConformanceResponseResult(
+          kind: ConformanceResponseResultKind.parse_error,
+          parse_error: "parse_error: " & exc.msg
+        )
+      )
 
 proc doTest(request: ConformanceRequest): ConformanceResponse =
   if request.requested_output_format != WireFormat.PROTOBUF or
-      request.payload.kind != PayloadKind.protobuf_payload:
-    ConformanceResponse(result: Result(kind: ResultKind.skipped, skipped: "skip not protobuf"))
+      request.payload.kind != ConformanceRequestPayloadKind.protobuf_payload:
+    ConformanceResponse(
+      result: ConformanceResponseResult(
+        kind: ConformanceResponseResultKind.skipped,
+        skipped: "skip not protobuf"
+      )
+    )
   elif request.message_type == "protobuf_test_messages.proto3.TestAllTypesProto3":
     processPayload(request.payload.protobuf_payload, TestAllTypesProto3)
   elif request.message_type == "protobuf_test_messages.proto2.TestAllTypesProto2":
     processPayload(request.payload.protobuf_payload, TestAllTypesProto2)
   else:
-    ConformanceResponse(result: Result(kind: ResultKind.skipped, skipped: "skip unknown message type: " & request.message_type))
+    ConformanceResponse(
+      result: ConformanceResponseResult(
+        kind: ConformanceResponseResultKind.skipped,
+        skipped: "skip unknown message type: " & request.message_type
+      )
+    )
 
 proc doTest(): bool =
   let length =

--- a/tests/conformance/failure_list.txt
+++ b/tests/conformance/failure_list.txt
@@ -20,7 +20,5 @@ Required.Proto2.ProtobufInput.ValidDataOneof.MESSAGE.NonDefaultValue.ProtobufOut
 Required.Proto2.ProtobufInput.ValidDataRepeated.MESSAGE.ProtobufOutput # Output was not equivalent to reference message: deleted: repeated_nested_message[0]: { }deleted: repeated_nested_message[1]: { a
 Required.Proto2.ProtobufInput.ValidDataScalar.MESSAGE[0].ProtobufOutput # Output was not equivalent to reference message: deleted: optional_nested_message: { }
 Required.Proto2.ProtobufInput.ValidDataScalar.MESSAGE[1].ProtobufOutput # Output was not equivalent to reference message: deleted: optional_nested_message: { a: 1234 }
-Required.Proto3.ProtobufInput.RepeatedScalarMessageMerge.ProtobufOutput # Output was not equivalent to reference message: deleted: optional_nested_message.corecursive.optional_int64: 1234modified: optio
 Required.Proto3.ProtobufInput.UnknownOrdering.ProtobufOutput # Unknown field mismatch
 Required.Proto3.ProtobufInput.UnknownVarint.ProtobufOutput # Output was not equivalent to reference message: Expect: \250\037\001, but got: 
-Required.Proto3.ProtobufInput.ValidDataOneof.MESSAGE.Merge.ProtobufOutput # Output was not equivalent to reference message: deleted: oneof_nested_message.corecursive.optional_int32: 1deleted: oneof_nested

--- a/tests/conformance/failure_list.txt
+++ b/tests/conformance/failure_list.txt
@@ -12,30 +12,15 @@ Required.Proto2.ProtobufInput.ValidDataMap.STRING.MESSAGE.MergeValue.ProtobufOut
 Required.Proto2.ProtobufInput.ValidDataMap.STRING.MESSAGE.MissingDefault.ProtobufOutput # Output was not equivalent to reference message: deleted: map_string_nested_message['']: { }
 Required.Proto2.ProtobufInput.ValidDataMap.STRING.MESSAGE.NonDefault.ProtobufOutput # Output was not equivalent to reference message: deleted: map_string_nested_message[a]: { a: 1234 }
 Required.Proto2.ProtobufInput.ValidDataMap.STRING.MESSAGE.Unordered.ProtobufOutput # Output was not equivalent to reference message: deleted: map_string_nested_message[a]: { a: 1234 }
-Required.Proto2.ProtobufInput.ValidDataOneof.BOOL.MultipleValuesForDifferentField.ProtobufOutput # Output was not equivalent to reference message: added: oneof_uint32: 0deleted: oneof_bool: true
-Required.Proto2.ProtobufInput.ValidDataOneof.BYTES.MultipleValuesForDifferentField.ProtobufOutput # Output was not equivalent to reference message: added: oneof_uint32: 0deleted: oneof_bytes: "a"
-Required.Proto2.ProtobufInput.ValidDataOneof.DOUBLE.MultipleValuesForDifferentField.ProtobufOutput # Output was not equivalent to reference message: added: oneof_uint32: 0deleted: oneof_double: 1
-Required.Proto2.ProtobufInput.ValidDataOneof.ENUM.MultipleValuesForDifferentField.ProtobufOutput # Output was not equivalent to reference message: added: oneof_uint32: 0deleted: oneof_enum: BAR
-Required.Proto2.ProtobufInput.ValidDataOneof.FLOAT.MultipleValuesForDifferentField.ProtobufOutput # Output was not equivalent to reference message: added: oneof_uint32: 0deleted: oneof_float: 1
 Required.Proto2.ProtobufInput.ValidDataOneof.MESSAGE.DefaultValue.ProtobufOutput # Output was not equivalent to reference message: deleted: oneof_nested_message: { }
 Required.Proto2.ProtobufInput.ValidDataOneof.MESSAGE.Merge.ProtobufOutput # Output was not equivalent to reference message: deleted: oneof_nested_message: { corecursive { optional_int32: 1 optional_int64:
 Required.Proto2.ProtobufInput.ValidDataOneof.MESSAGE.MultipleValuesForDifferentField.ProtobufOutput # Output was not equivalent to reference message: added: oneof_uint32: 0deleted: oneof_nested_message: { a: 1234 }
 Required.Proto2.ProtobufInput.ValidDataOneof.MESSAGE.MultipleValuesForSameField.ProtobufOutput # Output was not equivalent to reference message: deleted: oneof_nested_message: { a: 1234 }
 Required.Proto2.ProtobufInput.ValidDataOneof.MESSAGE.NonDefaultValue.ProtobufOutput # Output was not equivalent to reference message: deleted: oneof_nested_message: { a: 1234 }
-Required.Proto2.ProtobufInput.ValidDataOneof.STRING.MultipleValuesForDifferentField.ProtobufOutput # Output was not equivalent to reference message: added: oneof_uint32: 0deleted: oneof_string: "a"
-Required.Proto2.ProtobufInput.ValidDataOneof.UINT64.MultipleValuesForDifferentField.ProtobufOutput # Output was not equivalent to reference message: added: oneof_uint32: 0deleted: oneof_uint64: 1
 Required.Proto2.ProtobufInput.ValidDataRepeated.MESSAGE.ProtobufOutput # Output was not equivalent to reference message: deleted: repeated_nested_message[0]: { }deleted: repeated_nested_message[1]: { a
 Required.Proto2.ProtobufInput.ValidDataScalar.MESSAGE[0].ProtobufOutput # Output was not equivalent to reference message: deleted: optional_nested_message: { }
 Required.Proto2.ProtobufInput.ValidDataScalar.MESSAGE[1].ProtobufOutput # Output was not equivalent to reference message: deleted: optional_nested_message: { a: 1234 }
 Required.Proto3.ProtobufInput.RepeatedScalarMessageMerge.ProtobufOutput # Output was not equivalent to reference message: deleted: optional_nested_message.corecursive.optional_int64: 1234modified: optio
 Required.Proto3.ProtobufInput.UnknownOrdering.ProtobufOutput # Unknown field mismatch
 Required.Proto3.ProtobufInput.UnknownVarint.ProtobufOutput # Output was not equivalent to reference message: Expect: \250\037\001, but got: 
-Required.Proto3.ProtobufInput.ValidDataOneof.BOOL.DefaultValue.ProtobufOutput # Output was not equivalent to reference message: deleted: oneof_bool: false
-Required.Proto3.ProtobufInput.ValidDataOneof.BYTES.DefaultValue.ProtobufOutput # Output was not equivalent to reference message: deleted: oneof_bytes: ""
-Required.Proto3.ProtobufInput.ValidDataOneof.DOUBLE.DefaultValue.ProtobufOutput # Output was not equivalent to reference message: deleted: oneof_double: 0
-Required.Proto3.ProtobufInput.ValidDataOneof.ENUM.DefaultValue.ProtobufOutput # Output was not equivalent to reference message: deleted: oneof_enum: FOO
-Required.Proto3.ProtobufInput.ValidDataOneof.FLOAT.DefaultValue.ProtobufOutput # Output was not equivalent to reference message: deleted: oneof_float: 0
 Required.Proto3.ProtobufInput.ValidDataOneof.MESSAGE.Merge.ProtobufOutput # Output was not equivalent to reference message: deleted: oneof_nested_message.corecursive.optional_int32: 1deleted: oneof_nested
-Required.Proto3.ProtobufInput.ValidDataOneof.STRING.DefaultValue.ProtobufOutput # Output was not equivalent to reference message: deleted: oneof_string: ""
-Required.Proto3.ProtobufInput.ValidDataOneof.UINT32.DefaultValue.ProtobufOutput # Output was not equivalent to reference message: deleted: oneof_uint32: 0
-Required.Proto3.ProtobufInput.ValidDataOneof.UINT64.DefaultValue.ProtobufOutput # Output was not equivalent to reference message: deleted: oneof_uint64: 0

--- a/tests/fail/test_invalid_oneof_extra_fieldnumber.nim
+++ b/tests/fail/test_invalid_oneof_extra_fieldnumber.nim
@@ -1,0 +1,22 @@
+import ../../protobuf_serialization
+
+type
+  Kind1 {.pure.} = enum
+    unset
+    x
+    y
+
+  OneOf1 {.proto3, oneof.} = object
+    case kind: Kind1
+    of Kind1.unset:
+      discard
+    of Kind1.x:
+      x {.fieldNumber: 1, pint.}: int64
+    of Kind1.y:
+      y {.fieldNumber: 2, pint.}: int64
+
+  Obj1 {.proto3.} = object
+    #one {.oneof.}: OneOf1
+    one {.fieldNumber: 9, oneof.}: OneOf1
+
+discard Protobuf.encode(Obj1())

--- a/tests/fail/test_invalid_oneof_fieldnumber.nim
+++ b/tests/fail/test_invalid_oneof_fieldnumber.nim
@@ -1,0 +1,22 @@
+import ../../protobuf_serialization
+
+type
+  Kind1 {.pure.} = enum
+    unset
+    x
+    y
+
+  OneOf1 {.proto3, oneof.} = object
+    case kind: Kind1
+    of Kind1.unset:
+      discard
+    of Kind1.x:
+      #x {.fieldNumber: 1, pint.}: int64
+      x {.fieldNumber: -1, pint.}: int64
+    of Kind1.y:
+      y {.fieldNumber: 2, pint.}: int64
+
+  Obj1 {.proto3.} = object
+    one {.oneof.}: OneOf1
+
+discard Protobuf.encode(Obj1())

--- a/tests/fail/test_invalid_oneof_missing_oneof.nim
+++ b/tests/fail/test_invalid_oneof_missing_oneof.nim
@@ -1,0 +1,22 @@
+import ../../protobuf_serialization
+
+type
+  Kind1 {.pure.} = enum
+    unset
+    x
+    y
+
+  #OneOf1 {.proto3, oneof.} = object
+  OneOf1 {.proto3.} = object
+    case kind: Kind1
+    of Kind1.unset:
+      discard
+    of Kind1.x:
+      x {.fieldNumber: 1, pint.}: int64
+    of Kind1.y:
+      y {.fieldNumber: 2, pint.}: int64
+
+  Obj1 {.proto3.} = object
+    one {.oneof.}: OneOf1
+
+discard Protobuf.encode(Obj1())

--- a/tests/fail/test_invalid_oneof_missing_proto.nim
+++ b/tests/fail/test_invalid_oneof_missing_proto.nim
@@ -1,0 +1,22 @@
+import ../../protobuf_serialization
+
+type
+  Kind1 {.pure.} = enum
+    unset
+    x
+    y
+
+  #OneOf1 {.proto3, oneof.} = object
+  OneOf1 {.oneof.} = object
+    case kind: Kind1
+    of Kind1.unset:
+      discard
+    of Kind1.x:
+      x {.fieldNumber: 1, pint.}: int64
+    of Kind1.y:
+      y {.fieldNumber: 2, pint.}: int64
+
+  Obj1 {.proto3.} = object
+    one {.oneof.}: OneOf1
+
+discard Protobuf.encode(Obj1())

--- a/tests/fail/test_invalid_oneof_missing_unset.nim
+++ b/tests/fail/test_invalid_oneof_missing_unset.nim
@@ -1,0 +1,21 @@
+import ../../protobuf_serialization
+
+type
+  Kind1 {.pure.} = enum
+    #unset
+    x
+    y
+
+  OneOf1 {.proto3, oneof.} = object
+    case kind: Kind1
+    #of Kind1.unset:
+    #  discard
+    of Kind1.x:
+      x {.fieldNumber: 1, pint.}: int64
+    of Kind1.y:
+      y {.fieldNumber: 2, pint.}: int64
+
+  Obj1 {.proto3.} = object
+    one {.oneof.}: OneOf1
+
+discard Protobuf.encode(Obj1())

--- a/tests/fail/test_invalid_oneof_multi_cases.nim
+++ b/tests/fail/test_invalid_oneof_multi_cases.nim
@@ -1,0 +1,28 @@
+import ../../protobuf_serialization
+
+type
+  Kind1 {.pure.} = enum
+    unset
+    x
+    y
+
+  OneOf1 {.proto2, oneof.} = object
+    case kind: Kind1
+    of Kind1.unset:
+      discard
+    of Kind1.x:
+      x {.fieldNumber: 1, pint.}: int64
+    of Kind1.y:
+      y {.fieldNumber: 2, pint.}: int64
+    case kind2: Kind1
+    of Kind1.unset:
+      discard
+    of Kind1.x:
+      a {.fieldNumber: 3, pint.}: int64
+    of Kind1.y:
+      b {.fieldNumber: 4, pint.}: int64
+
+  Obj1 {.proto2.} = object
+    one {.oneof.}: OneOf1
+
+discard Protobuf.encode(Obj1())

--- a/tests/fail/test_invalid_oneof_multi_field.nim
+++ b/tests/fail/test_invalid_oneof_multi_field.nim
@@ -1,0 +1,22 @@
+import ../../protobuf_serialization
+
+type
+  Kind1 {.pure.} = enum
+    unset
+    x
+    y
+
+  OneOf1 {.proto3, oneof.} = object
+    case kind: Kind1
+    of Kind1.unset:
+      discard
+    of Kind1.x:
+      x {.fieldNumber: 1, pint.}: int64
+    of Kind1.y:
+      y {.fieldNumber: 2, pint.}: int64
+      z {.fieldNumber: 3, pint.}: int64
+
+  Obj1 {.proto3.} = object
+    one {.oneof.}: OneOf1
+
+discard Protobuf.encode(Obj1())

--- a/tests/fail/test_invalid_oneof_nested.nim
+++ b/tests/fail/test_invalid_oneof_nested.nim
@@ -1,0 +1,30 @@
+import ../../protobuf_serialization
+
+type
+  Kind1 {.pure.} = enum
+    unset
+    x
+    y
+
+  OneOf2 {.proto3, oneof.} = object
+    case kind: Kind1
+    of Kind1.unset:
+      discard
+    of Kind1.x:
+      x {.fieldNumber: 1, pint.}: int64
+    of Kind1.y:
+      y {.fieldNumber: 2, pint.}: int64
+
+  OneOf1 {.proto3, oneof.} = object
+    case kind: Kind1
+    of Kind1.unset:
+      discard
+    of Kind1.x:
+      x {.fieldNumber: 1, oneof.}: OneOf2
+    of Kind1.y:
+      y {.fieldNumber: 2, pint.}: int64
+
+  Obj1 {.proto3.} = object
+    one {.oneof.}: OneOf1
+
+discard Protobuf.encode(Obj1())

--- a/tests/fail/test_invalid_oneof_pboption.nim
+++ b/tests/fail/test_invalid_oneof_pboption.nim
@@ -1,0 +1,22 @@
+import ../../protobuf_serialization
+
+type
+  Kind1 {.pure.} = enum
+    unset
+    x
+    y
+
+  OneOf1 {.proto2, oneof.} = object
+    case kind: Kind1
+    of Kind1.unset:
+      discard
+    of Kind1.x:
+      x {.fieldNumber: 1, pint.}: int64
+    of Kind1.y:
+      y {.fieldNumber: 2, pint.}: int64
+
+  Obj1 {.proto2.} = object
+    #one {.oneof.}: OneOf1
+    one {.oneof.}: PBOption[default(OneOf1)]
+
+discard Protobuf.encode(Obj1())

--- a/tests/fail/test_invalid_oneof_pboption_field.nim
+++ b/tests/fail/test_invalid_oneof_pboption_field.nim
@@ -1,0 +1,22 @@
+import ../../protobuf_serialization
+
+type
+  Kind1 {.pure.} = enum
+    unset
+    x
+    y
+
+  OneOf1 {.proto2, oneof.} = object
+    case kind: Kind1
+    of Kind1.unset:
+      discard
+    of Kind1.x:
+      #x {.fieldNumber: 1, pint.}: int64
+      x {.fieldNumber: 1, pint.}: PBOption[0'i64]
+    of Kind1.y:
+      y {.fieldNumber: 2, pint.}: int64
+
+  Obj1 {.proto2.} = object
+    one {.oneof.}: OneOf1
+
+discard Protobuf.encode(Obj1())

--- a/tests/fail/test_invalid_oneof_pboption_fieldnum.nim
+++ b/tests/fail/test_invalid_oneof_pboption_fieldnum.nim
@@ -1,0 +1,22 @@
+import ../../protobuf_serialization
+
+type
+  Kind1 {.pure.} = enum
+    unset
+    x
+    y
+
+  OneOf1 {.proto2, oneof.} = object
+    case kind: Kind1
+    of Kind1.unset:
+      discard
+    of Kind1.x:
+      x {.fieldNumber: 1, pint.}: int64
+    of Kind1.y:
+      y {.fieldNumber: 2, pint.}: int64
+
+  Obj1 {.proto2.} = object
+    #one {.oneof.}: OneOf1
+    one {.fieldNumber: 9.}: PBOption[default(OneOf1)]
+
+discard Protobuf.encode(Obj1())

--- a/tests/fail/test_invalid_oneof_repeated_fieldnumber.nim
+++ b/tests/fail/test_invalid_oneof_repeated_fieldnumber.nim
@@ -1,0 +1,22 @@
+import ../../protobuf_serialization
+
+type
+  Kind1 {.pure.} = enum
+    unset
+    x
+    y
+
+  OneOf1 {.proto3, oneof.} = object
+    case kind: Kind1
+    of Kind1.unset:
+      discard
+    of Kind1.x:
+      x {.fieldNumber: 1, pint.}: int64
+    of Kind1.y:
+      y {.fieldNumber: 2, pint.}: int64
+
+  Obj1 {.proto3.} = object
+    one {.oneof.}: OneOf1
+    x {.fieldNumber: 1, pint.}: int64
+
+discard Protobuf.encode(Obj1())

--- a/tests/fail/test_invalid_oneof_repeated_fieldnumber_2.nim
+++ b/tests/fail/test_invalid_oneof_repeated_fieldnumber_2.nim
@@ -1,0 +1,22 @@
+import ../../protobuf_serialization
+
+type
+  Kind1 {.pure.} = enum
+    unset
+    x
+    y
+
+  OneOf1 {.proto3, oneof.} = object
+    case kind: Kind1
+    of Kind1.unset:
+      discard
+    of Kind1.x:
+      x {.fieldNumber: 1, pint.}: int64
+    of Kind1.y:
+      #y {.fieldNumber: 2, pint.}: int64
+      y {.fieldNumber: 1, pint.}: int64
+
+  Obj1 {.proto3.} = object
+    one {.oneof.}: OneOf1
+
+discard Protobuf.encode(Obj1())

--- a/tests/fail/test_invalid_oneof_required.nim
+++ b/tests/fail/test_invalid_oneof_required.nim
@@ -1,0 +1,22 @@
+import ../../protobuf_serialization
+
+type
+  Kind1 {.pure.} = enum
+    unset
+    x
+    y
+
+  OneOf1 {.proto2, oneof.} = object
+    case kind: Kind1
+    of Kind1.unset:
+      discard
+    of Kind1.x:
+      x {.fieldNumber: 1, pint.}: int64
+    of Kind1.y:
+      y {.fieldNumber: 2, pint.}: int64
+
+  Obj1 {.proto2.} = object
+    #one {.oneof.}: OneOf1
+    one {.oneof, required.}: OneOf1
+
+discard Protobuf.encode(Obj1())

--- a/tests/fail/test_invalid_oneof_seq.nim
+++ b/tests/fail/test_invalid_oneof_seq.nim
@@ -1,0 +1,22 @@
+import ../../protobuf_serialization
+
+type
+  Kind1 {.pure.} = enum
+    unset
+    x
+    y
+
+  OneOf1 {.proto3, oneof.} = object
+    case kind: Kind1
+    of Kind1.unset:
+      discard
+    of Kind1.x:
+      x {.fieldNumber: 1, pint.}: int64
+    of Kind1.y:
+      y {.fieldNumber: 2, pint.}: int64
+
+  Obj1 {.proto3.} = object
+    #one {.oneof.}: OneOf1
+    one {.oneof.}: seq[OneOf1]
+
+discard Protobuf.encode(Obj1())

--- a/tests/fail/test_invalid_oneof_seq_field.nim
+++ b/tests/fail/test_invalid_oneof_seq_field.nim
@@ -1,0 +1,22 @@
+import ../../protobuf_serialization
+
+type
+  Kind1 {.pure.} = enum
+    unset
+    x
+    y
+
+  OneOf1 {.proto3, oneof.} = object
+    case kind: Kind1
+    of Kind1.unset:
+      discard
+    of Kind1.x:
+      #x {.fieldNumber: 1, pint.}: int64
+      x {.fieldNumber: 1, pint.}: seq[int64]
+    of Kind1.y:
+      y {.fieldNumber: 2, pint.}: int64
+
+  Obj1 {.proto3.} = object
+    one {.oneof.}: OneOf1
+
+discard Protobuf.encode(Obj1())

--- a/tests/fail/test_invalid_oneof_top_level_field.nim
+++ b/tests/fail/test_invalid_oneof_top_level_field.nim
@@ -1,0 +1,22 @@
+import ../../protobuf_serialization
+
+type
+  Kind1 {.pure.} = enum
+    unset
+    x
+    y
+
+  OneOf1 {.proto3, oneof.} = object
+    case kind: Kind1
+    of Kind1.unset:
+      discard
+    of Kind1.x:
+      x {.fieldNumber: 1, pint.}: int64
+    of Kind1.y:
+      y {.fieldNumber: 2, pint.}: int64
+    z {.fieldNumber: 3, pint.}: int64
+
+  Obj1 {.proto3.} = object
+    one {.oneof.}: OneOf1
+
+discard Protobuf.encode(Obj1())

--- a/tests/files/test.proto3
+++ b/tests/files/test.proto3
@@ -39,3 +39,19 @@ message ErrorStatus {
   string message = 1;
   repeated google.protobuf.Any details = 2;
 }
+
+message TestOneOf {
+  int32 pre = 1;
+  oneof oneof_field {
+    uint32 oneof_uint32 = 3;
+    string oneof_string = 4;
+    bytes oneof_bytes = 5;
+    bool oneof_bool = 6;
+    uint64 oneof_uint64 = 7;
+    float oneof_float = 8;
+    double oneof_double = 9;
+    TestEnum oneof_enum = 10;
+    google.protobuf.Any oneof_any = 11;
+  }
+  int32 post = 2;
+}

--- a/tests/files/test_proto3.nim
+++ b/tests/files/test_proto3.nim
@@ -5,22 +5,62 @@ import
   ../../protobuf_serialization/files/type_generator
 
 macro test() =
-  var
-    parsed: NimNode = protoToTypesInternal(currentSourcePath.parentDir / "test.proto3")
-    vector: NimNode = quote do:
+  let
+    parsed = protoToTypesInternal(currentSourcePath.parentDir / "test.proto3")
+    vector = quote do:
       type
         TestEnum* {.pure, proto3.} = enum
           UNKNOWN = 0
           STARTED = 1
 
+        Oneof_fieldKind* {.pure, proto3.} = enum
+          unset = 0
+          oneof_uint32 = 1
+          oneof_string = 2
+          oneof_bytes = 3
+          oneof_bool = 4
+          oneof_uint64 = 5
+          oneof_float = 6
+          oneof_double = 7
+          oneof_enum = 8
+          oneof_any = 9
+
+        Oneof_field* {.proto3, oneof.} = object
+          case kind*: Oneof_fieldKind
+          of Oneof_fieldKind.unset:
+            discard
+          of Oneof_fieldKind.oneof_uint32:
+            oneof_uint32* {.fieldNumber: 3, pint.}: uint32
+          of Oneof_fieldKind.oneof_string:
+            oneof_string* {.fieldNumber: 4.}: string
+          of Oneof_fieldKind.oneof_bytes:
+            oneof_bytes* {.fieldNumber: 5.}: seq[byte]
+          of Oneof_fieldKind.oneof_bool:
+            oneof_bool* {.fieldNumber: 6.}: bool
+          of Oneof_fieldKind.oneof_uint64:
+            oneof_uint64* {.fieldNumber: 7, pint.}: uint64
+          of Oneof_fieldKind.oneof_float:
+            oneof_float* {.fieldNumber: 8.}: float32
+          of Oneof_fieldKind.oneof_double:
+            oneof_double* {.fieldNumber: 9.}: float64
+          of Oneof_fieldKind.oneof_enum:
+            oneof_enum* {.fieldNumber: 10, ext.}: TestEnum
+          of Oneof_fieldKind.oneof_any:
+            oneof_any* {.fieldNumber: 11.}: seq[byte]
+
+        TestOneOf* {.proto3.} = object
+          pre* {.fieldNumber: 1, pint.}: int32
+          oneof_field* {.oneof.}: Oneof_field
+          post* {.fieldNumber: 2, pint.}: int32
+
         ErrorStatus* {.proto3.} = object
-          details* {.fieldNumber: 2.}: seq[seq[byte]]
           message* {.fieldNumber: 1.}: string
+          details* {.fieldNumber: 2.}: seq[seq[byte]]
 
         Result* {.proto3.} = object
-          snippets* {.fieldNumber: 3.}: seq[string]
-          title* {.fieldNumber: 2.}: string
           url* {.fieldNumber: 1.}: string
+          title* {.fieldNumber: 2.}: string
+          snippets* {.fieldNumber: 3.}: seq[string]
 
         SearchResponse* {.proto3.} = object
           results* {.fieldNumber: 1.}: seq[Result]
@@ -35,32 +75,37 @@ macro test() =
           VIDEO = 6
 
         SearchRequest* {.proto3.} = object
-          corpus* {.fieldNumber: 4, ext.}: Corpus
-          result_per_page* {.fieldNumber: 3, pint.}: int32
-          page_number* {.fieldNumber: 2, pint.}: int32
           query* {.fieldNumber: 1.}: string
+          page_number* {.fieldNumber: 2, pint.}: int32
+          result_per_page* {.fieldNumber: 3, pint.}: int32
+          corpus* {.fieldNumber: 4, ext.}: Corpus
 
         Foo* {.proto3.} = object
 
-  proc convertFromSym(parent: NimNode, i: int) =
-    if parent[i].kind == nnkSym:
-      parent[i] = ident(parent[i].strVal)
-    elif parent[i].kind == nnkIdent:
-      parent[i] = ident(parent[i].strVal.split('`')[0])
-    elif parent[i].kind == nnkCall:
-      parent[i] = newNimNode(nnkBracketExpr).add(
-        ident(parent[i][1].strVal),
-        parent[i][2]
-      )
-      if parent[i][1].kind == nnkSym:
-        parent[i][1] = ident(parent[i][1].strVal)
-    for c1 in 0 ..< parent.len:
-      for c2 in 0 ..< parent[c1].len:
-        convertFromSym(parent[c1], c2)
-  for c in 0 ..< vector.len:
-    convertFromSym(vector, c)
+  proc fixAst(ast: NimNode): NimNode =
+    proc inspect(node: NimNode): NimNode =
+      case node.kind
+      of {nnkIdent, nnkSym}:
+        # remove `gensymX
+        ident(split($node, '`')[0])
+      of nnkEmpty:
+        node
+      of nnkLiterals:
+        node
+      of nnkCall:
+        var ret = newNimNode(nnkBracketExpr)
+        for i in 1 ..< node.len:
+          ret.add inspect(node[i])
+        ret
+      else:
+        var rTree = node.kind.newTree()
+        for child in node:
+          rTree.add inspect(child)
+        rTree
 
-  if parsed != vector:
+    inspect(ast)
+
+  if parsed != vector.fixAst:
     raise newException(Exception, "Expected: " & repr(parsed))
 
 test()
@@ -68,6 +113,7 @@ test()
 import_proto3 "test.proto3"
 when not (
   Protobuf.supports(TestEnum) and
+  Protobuf.supports(TestOneOf) and
   Protobuf.supports(ErrorStatus) and
   Protobuf.supports(Result) and
   Protobuf.supports(SearchResponse) and

--- a/tests/files/test_proto3.nim
+++ b/tests/files/test_proto3.nim
@@ -13,7 +13,7 @@ macro test() =
           UNKNOWN = 0
           STARTED = 1
 
-        Oneof_fieldKind* {.pure, proto3.} = enum
+        TestOneOfOneof_fieldKind* {.pure, proto3.} = enum
           unset = 0
           oneof_uint32 = 1
           oneof_string = 2
@@ -25,32 +25,32 @@ macro test() =
           oneof_enum = 8
           oneof_any = 9
 
-        Oneof_field* {.proto3, oneof.} = object
-          case kind*: Oneof_fieldKind
-          of Oneof_fieldKind.unset:
+        TestOneOfOneof_field* {.proto3, oneof.} = object
+          case kind*: TestOneOfOneof_fieldKind
+          of TestOneOfOneof_fieldKind.unset:
             discard
-          of Oneof_fieldKind.oneof_uint32:
+          of TestOneOfOneof_fieldKind.oneof_uint32:
             oneof_uint32* {.fieldNumber: 3, pint.}: uint32
-          of Oneof_fieldKind.oneof_string:
+          of TestOneOfOneof_fieldKind.oneof_string:
             oneof_string* {.fieldNumber: 4.}: string
-          of Oneof_fieldKind.oneof_bytes:
+          of TestOneOfOneof_fieldKind.oneof_bytes:
             oneof_bytes* {.fieldNumber: 5.}: seq[byte]
-          of Oneof_fieldKind.oneof_bool:
+          of TestOneOfOneof_fieldKind.oneof_bool:
             oneof_bool* {.fieldNumber: 6.}: bool
-          of Oneof_fieldKind.oneof_uint64:
+          of TestOneOfOneof_fieldKind.oneof_uint64:
             oneof_uint64* {.fieldNumber: 7, pint.}: uint64
-          of Oneof_fieldKind.oneof_float:
+          of TestOneOfOneof_fieldKind.oneof_float:
             oneof_float* {.fieldNumber: 8.}: float32
-          of Oneof_fieldKind.oneof_double:
+          of TestOneOfOneof_fieldKind.oneof_double:
             oneof_double* {.fieldNumber: 9.}: float64
-          of Oneof_fieldKind.oneof_enum:
+          of TestOneOfOneof_fieldKind.oneof_enum:
             oneof_enum* {.fieldNumber: 10, ext.}: TestEnum
-          of Oneof_fieldKind.oneof_any:
+          of TestOneOfOneof_fieldKind.oneof_any:
             oneof_any* {.fieldNumber: 11.}: seq[byte]
 
         TestOneOf* {.proto3.} = object
           pre* {.fieldNumber: 1, pint.}: int32
-          oneof_field* {.oneof.}: Oneof_field
+          oneof_field* {.oneof.}: TestOneOfOneof_field
           post* {.fieldNumber: 2, pint.}: int32
 
         ErrorStatus* {.proto3.} = object

--- a/tests/test_extension.nim
+++ b/tests/test_extension.nim
@@ -9,6 +9,7 @@
 
 import
   unittest2,
+  stew/byteutils,
   ./utils,
   ../protobuf_serialization,
   ../protobuf_serialization/pkg/results
@@ -34,6 +35,20 @@ type
 
   Proto3Int32ExtSeq {.proto3.} = object
     a {.fieldNumber: 1, ext.}: seq[Int32Ext]
+
+  OneOfKind {.pure.} = enum
+    unset
+    x
+
+  OneOf {.proto3, oneof.} = object
+    case kind: OneOfKind
+    of OneOfKind.unset:
+      discard
+    of OneOfKind.x:
+      x {.fieldNumber: 1, ext.}: Int32Ext
+
+  Proto3Int32ExtOneOf {.proto3.} = object
+    one {.oneof.}: OneOf
 
 Protobuf.extensionDefaults(Int32Ext, defaultSeq = true, packed = false)
 
@@ -94,6 +109,14 @@ suite "Test Int32Ext":
     roundtrip(Proto3Int32ExtSeq(a: @[Int32Ext(x: 0'i32)]), "0800")
     roundtrip(default(Proto3Int32ExtSeq), "")
     roundtrip(Proto3Int32ExtSeq(a: @[Int32Ext(x: 1'i32), Int32Ext(x: 0'i32)]), "08010800")
+
+  test "proto3 oneof Int32Ext":
+    let encoded = "0801".hexToSeqByte
+    let ret = Protobuf.decode(encoded, Proto3Int32ExtOneOf)
+    check:
+      ret.one.kind == OneOfKind.x
+      ret.one.x == Int32Ext(x: 1'i32)
+      Protobuf.encode(ret) == encoded
 
 type
   Int32Ext2 = object

--- a/tests/test_oneof.nim
+++ b/tests/test_oneof.nim
@@ -1,0 +1,47 @@
+# nim-protobuf-serialization
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+import unittest2
+import stew/byteutils
+import ../protobuf_serialization
+
+type
+  OneOfKind {.pure.} = enum
+    unset
+    x
+    y
+  OneOf {.proto3.} = object
+    kind {.dontSerialize.}: OneOfKind
+    x {.fieldNumber: 1, pint.}: int64
+    y {.fieldNumber: 2, pint.}: int64
+  OneOfObj {.proto3.} = object
+    one {.oneof, dontSerialize.}: OneOf
+
+suite "Test oneof":
+  test "oneof unset":
+    let encoded = "".hexToSeqByte
+    check Protobuf.decode(encoded, OneOfObj) == OneOfObj(one: OneOf(kind: OneOfKind.unset))
+
+  test "oneof field 1 set":
+    # echo 'x: 1' | protoc --encode=OneOfObj test_oneof.proto | hexdump -ve '1/1 "%.2x"'
+    # 0801
+    let encoded = "0801".hexToSeqByte
+    check Protobuf.decode(encoded, OneOfObj) == OneOfObj(one: OneOf(kind: OneOfKind.x, x: 1))
+
+  test "oneof field 2 set":
+    let encoded = "1001".hexToSeqByte
+    check Protobuf.decode(encoded, OneOfObj) == OneOfObj(one: OneOf(kind: OneOfKind.y, y: 1))
+
+  test "oneof field 1 and 2 set":
+    let encoded = "08011001".hexToSeqByte
+    check Protobuf.decode(encoded, OneOfObj) == OneOfObj(one: OneOf(kind: OneOfKind.y, y: 1))
+
+  test "oneof field 1 and 2 set variant":
+    let encoded = "10010801".hexToSeqByte
+    check Protobuf.decode(encoded, OneOfObj) == OneOfObj(one: OneOf(kind: OneOfKind.x, x: 1))

--- a/tests/test_oneof.nim
+++ b/tests/test_oneof.nim
@@ -45,6 +45,10 @@ suite "Test oneof":
     let encoded = "10010801".hexToSeqByte
     check Protobuf.decode(encoded, OneOfObj) == OneOfObj(one: OneOfKind.x, x: 1)
 
+  test "oneof field 1 and 2 set":
+    let encoded = "0801".hexToSeqByte
+    check Protobuf.encode(OneOfObj(one: OneOfKind.x, x: 1, y: 1)) == encoded
+
 type
   OneOfKind1 {.pure.} = enum
     unset
@@ -75,6 +79,9 @@ suite "Test many oneof":
     check Protobuf.decode(encoded, OneOfManyObj) == OneOfManyObj(
       one: OneOfKind1.a, a: 1
     )
+    check Protobuf.encode(OneOfManyObj(
+      one: OneOfKind1.a, a: 1
+    )) == encoded
 
   test "many oneof field 3 set":
     let encoded = "1801".hexToSeqByte

--- a/tests/test_oneof.nim
+++ b/tests/test_oneof.nim
@@ -17,7 +17,7 @@ type
     x
     y
 
-  OneOf1 {.oneof.} = object
+  OneOf1 {.proto3, oneof.} = object
     case kind: Kind1
     of Kind1.unset:
       discard
@@ -78,7 +78,7 @@ suite "Test oneof":
       ret.one.x == 1
 
 type
-  OneOf2 {.oneof.} = object
+  OneOf2 {.proto3, oneof.} = object
     case kind: Kind1
     of Kind1.unset:
       discard

--- a/tests/test_oneof.nim
+++ b/tests/test_oneof.nim
@@ -211,6 +211,11 @@ type
     x12
     x13
     x14
+    x15
+
+  SomeMessage {.proto3.} = object
+    x {.fieldNumber: 1, pint.}: int32
+    y {.fieldNumber: 2, pint.}: int32
 
   OneOfAll {.proto3, oneof.} = object
     case kind: KindAll
@@ -244,6 +249,8 @@ type
       x13 {.fieldNumber: 13.}: float32
     of KindAll.x14:
       x14 {.fieldNumber: 14.}: float64
+    of KindAll.x15:
+      x15 {.fieldNumber: 15.}: SomeMessage
 
   ObjAll {.proto3.} = object
     one {.oneof.}: OneOfAll
@@ -295,3 +302,55 @@ suite "Test all types in oneof":
       ret.one.kind == KindAll.x09
       ret.one.x09 == 123
       Protobuf.encode(ret) == encoded
+
+  test "message default oneof set":
+    # echo 'x15: {}' | protoc --encode=ObjAll test_oneof.proto | hexdump -ve '1/1 "%.2x"'
+    # 7a00
+    let encoded = "7a00".hexToSeqByte
+    let ret = Protobuf.decode(encoded, ObjAll)
+    check:
+      ret.one.kind == KindAll.x15
+      ret.one.x15 == SomeMessage()
+      Protobuf.encode(ret) == encoded
+
+  test "message oneof set":
+    # echo 'x15: {x: 1}' | protoc --encode=ObjAll test_oneof.proto | hexdump -ve '1/1 "%.2x"'
+    # 7a020801
+    let encoded = "7a020801".hexToSeqByte
+    let ret = Protobuf.decode(encoded, ObjAll)
+    check:
+      ret.one.kind == KindAll.x15
+      ret.one.x15 == SomeMessage(x: 1)
+      Protobuf.encode(ret) == encoded
+
+  test "oneof message merge":
+    # d80701 is "123: 1" and splits the message
+    # echo "7a020801d807017a021001" | xxd -r -p | protoc --decode=ObjAll test_oneof.proto
+    # x15 {
+    #   x: 1
+    #   y: 1
+    # }
+    # 123: 1
+    # echo 'x15: {x: 1 y: 1}' | protoc --encode=ObjAll test_oneof.proto | hexdump -ve '1/1 "%.2x"'
+    # 7a0408011001
+    let encoded = "7a020801d807017a021001".hexToSeqByte
+    let ret = Protobuf.decode(encoded, ObjAll)
+    check:
+      ret.one.kind == KindAll.x15
+      ret.one.x15 == SomeMessage(x: 1, y: 1)
+      Protobuf.encode(ret) == "7a0408011001".hexToSeqByte
+
+  test "oneof message no merge":
+    # 7a020801 -> x15: {x: 1}
+    # 187b -> x03: 123
+    # 7a021001 -> x15: {y: 1}
+    # echo "7a020801187b7a021001" | xxd -r -p | protoc --decode=ObjAll test_oneof.proto
+    # x15 {
+    #   y: 1
+    # }
+    let encoded = "7a020801187b7a021001".hexToSeqByte
+    let ret = Protobuf.decode(encoded, ObjAll)
+    check:
+      ret.one.kind == KindAll.x15
+      ret.one.x15 == SomeMessage(y: 1)
+      Protobuf.encode(ret) == "7a021001".hexToSeqByte

--- a/tests/test_oneof.nim
+++ b/tests/test_oneof.nim
@@ -16,32 +16,88 @@ type
     unset
     x
     y
-  OneOf {.proto3.} = object
-    kind {.dontSerialize.}: OneOfKind
+
+  OneOfObj {.proto3.} = object
+    one {.oneof, dontSerialize.}: OneOfKind
     x {.fieldNumber: 1, pint.}: int64
     y {.fieldNumber: 2, pint.}: int64
-  OneOfObj {.proto3.} = object
-    one {.oneof, dontSerialize.}: OneOf
 
 suite "Test oneof":
   test "oneof unset":
     let encoded = "".hexToSeqByte
-    check Protobuf.decode(encoded, OneOfObj) == OneOfObj(one: OneOf(kind: OneOfKind.unset))
+    check Protobuf.decode(encoded, OneOfObj) == OneOfObj(one: OneOfKind.unset)
 
   test "oneof field 1 set":
     # echo 'x: 1' | protoc --encode=OneOfObj test_oneof.proto | hexdump -ve '1/1 "%.2x"'
     # 0801
     let encoded = "0801".hexToSeqByte
-    check Protobuf.decode(encoded, OneOfObj) == OneOfObj(one: OneOf(kind: OneOfKind.x, x: 1))
+    check Protobuf.decode(encoded, OneOfObj) == OneOfObj(one: OneOfKind.x, x: 1)
 
   test "oneof field 2 set":
     let encoded = "1001".hexToSeqByte
-    check Protobuf.decode(encoded, OneOfObj) == OneOfObj(one: OneOf(kind: OneOfKind.y, y: 1))
+    check Protobuf.decode(encoded, OneOfObj) == OneOfObj(one: OneOfKind.y, y: 1)
 
   test "oneof field 1 and 2 set":
     let encoded = "08011001".hexToSeqByte
-    check Protobuf.decode(encoded, OneOfObj) == OneOfObj(one: OneOf(kind: OneOfKind.y, y: 1))
+    check Protobuf.decode(encoded, OneOfObj) == OneOfObj(one: OneOfKind.y, y: 1)
 
   test "oneof field 1 and 2 set variant":
     let encoded = "10010801".hexToSeqByte
-    check Protobuf.decode(encoded, OneOfObj) == OneOfObj(one: OneOf(kind: OneOfKind.x, x: 1))
+    check Protobuf.decode(encoded, OneOfObj) == OneOfObj(one: OneOfKind.x, x: 1)
+
+type
+  OneOfKind1 {.pure.} = enum
+    unset
+    a
+    b
+
+  OneOfKind2 {.pure.} = enum
+    unset
+    c
+    d
+
+  OneOfManyObj {.proto3.} = object
+    one {.oneof, dontSerialize.}: OneOfKind1
+    a {.fieldNumber: 1, pint.}: int64
+    b {.fieldNumber: 2, pint.}: int64
+    two {.oneof, dontSerialize.}: OneOfKind2
+    c {.fieldNumber: 3, pint.}: int64
+    d {.fieldNumber: 4, pint.}: int64
+
+suite "Test many oneof":
+  test "many oneof unset":
+    let encoded = "".hexToSeqByte
+    check Protobuf.decode(encoded, OneOfManyObj) ==
+      OneOfManyObj(one: OneOfKind1.unset, two: OneOfKind2.unset)
+
+  test "many oneof field 1 set":
+    let encoded = "0801".hexToSeqByte
+    check Protobuf.decode(encoded, OneOfManyObj) == OneOfManyObj(
+      one: OneOfKind1.a, a: 1
+    )
+
+  test "many oneof field 3 set":
+    let encoded = "1801".hexToSeqByte
+    check Protobuf.decode(encoded, OneOfManyObj) == OneOfManyObj(
+      two: OneOfKind2.c, c: 1
+    )
+
+  test "many oneof field 1 and 3 set":
+    let encoded = "08011801".hexToSeqByte
+    check Protobuf.decode(encoded, OneOfManyObj) ==
+      OneOfManyObj(one: OneOfKind1.a, a: 1, two: OneOfKind2.c, c: 1)
+
+  test "many oneof field 1 and 3 set variant":
+    let encoded = "1001200108011801".hexToSeqByte
+    check Protobuf.decode(encoded, OneOfManyObj) ==
+      OneOfManyObj(one: OneOfKind1.a, a: 1, two: OneOfKind2.c, c: 1)
+
+  test "many oneof field 2 and 4 set":
+    let encoded = "10012001".hexToSeqByte
+    check Protobuf.decode(encoded, OneOfManyObj) ==
+      OneOfManyObj(one: OneOfKind1.b, b: 1, two: OneOfKind2.d, d: 1)
+
+  test "many oneof field 2 and 4 set variant":
+    let encoded = "0801180110012001".hexToSeqByte
+    check Protobuf.decode(encoded, OneOfManyObj) ==
+      OneOfManyObj(one: OneOfKind1.b, b: 1, two: OneOfKind2.d, d: 1)

--- a/tests/test_oneof.nim
+++ b/tests/test_oneof.nim
@@ -37,6 +37,14 @@ suite "Test oneof":
       ret.one.kind == Kind1.unset
       Protobuf.encode(ret) == encoded
 
+  test "oneof field 1 set to default":
+    let encoded = "0800".hexToSeqByte
+    let ret = Protobuf.decode(encoded, Obj1)
+    check:
+      ret.one.kind == Kind1.x
+      ret.one.x == 0
+      Protobuf.encode(ret) == encoded
+
   test "oneof field 1 set":
     # echo 'x: 1' | protoc --encode=OneOfObj test_oneof.proto | hexdump -ve '1/1 "%.2x"'
     # 0801
@@ -92,6 +100,15 @@ suite "Test many oneof":
       ret.two.kind == Kind1.unset
       Protobuf.encode(ret) == encoded
 
+  test "many oneof field 1 set to default":
+    let encoded = "0800".hexToSeqByte
+    let ret = Protobuf.decode(encoded, Obj2)
+    check:
+      ret.one.kind == Kind1.x
+      ret.one.x == 0
+      ret.two.kind == Kind1.unset
+      Protobuf.encode(ret) == encoded
+
   test "many oneof field 1 set":
     let encoded = "0801".hexToSeqByte
     let ret = Protobuf.decode(encoded, Obj2)
@@ -99,6 +116,15 @@ suite "Test many oneof":
       ret.one.kind == Kind1.x
       ret.one.x == 1
       ret.two.kind == Kind1.unset
+      Protobuf.encode(ret) == encoded
+
+  test "many oneof field 3 set to default":
+    let encoded = "1800".hexToSeqByte
+    let ret = Protobuf.decode(encoded, Obj2)
+    check:
+      ret.one.kind == Kind1.unset
+      ret.two.kind == Kind1.x
+      ret.two.x == 0
       Protobuf.encode(ret) == encoded
 
   test "many oneof field 3 set":
@@ -120,6 +146,16 @@ suite "Test many oneof":
       ret.two.x == 1
       Protobuf.encode(ret) == encoded
 
+  test "many oneof field 1 and 3 set to default":
+    let encoded = "08001800".hexToSeqByte
+    let ret = Protobuf.decode(encoded, Obj2)
+    check:
+      ret.one.kind == Kind1.x
+      ret.one.x == 0
+      ret.two.kind == Kind1.x
+      ret.two.x == 0
+      Protobuf.encode(ret) == encoded
+
   test "many oneof field 1 and 3 set variant":
     let encoded = "1001200108011801".hexToSeqByte
     let ret = Protobuf.decode(encoded, Obj2)
@@ -128,6 +164,16 @@ suite "Test many oneof":
       ret.one.x == 1
       ret.two.kind == Kind1.x
       ret.two.x == 1
+
+  test "many oneof field 2 and 4 set to default":
+    let encoded = "10002000".hexToSeqByte
+    let ret = Protobuf.decode(encoded, Obj2)
+    check:
+      ret.one.kind == Kind1.y
+      ret.one.y == 0
+      ret.two.kind == Kind1.y
+      ret.two.y == 0
+      Protobuf.encode(ret) == encoded
 
   test "many oneof field 2 and 4 set":
     let encoded = "10012001".hexToSeqByte

--- a/tests/test_oneof.nim
+++ b/tests/test_oneof.nim
@@ -193,3 +193,105 @@ suite "Test many oneof":
       ret.one.y == 1
       ret.two.kind == Kind1.y
       ret.two.y == 1
+
+type
+  KindAll {.pure.} = enum
+    unset
+    x01
+    x02
+    x03
+    x04
+    x05
+    x06
+    x07
+    x08
+    x09
+    x10
+    x11
+    x12
+    x13
+    x14
+
+  OneOfAll {.proto3, oneof.} = object
+    case kind: KindAll
+    of KindAll.unset:
+      discard
+    of KindAll.x01:
+      x01 {.fieldNumber: 1.}: string
+    of KindAll.x02:
+      x02 {.fieldNumber: 2.}: seq[byte]
+    of KindAll.x03:
+      x03 {.fieldNumber: 3, pint.}: int32
+    of KindAll.x04:
+      x04 {.fieldNumber: 4, pint.}: uint32
+    of KindAll.x05:
+      x05 {.fieldNumber: 5, pint.}: int64
+    of KindAll.x06:
+      x06 {.fieldNumber: 6, pint.}: uint64
+    of KindAll.x07:
+      x07 {.fieldNumber: 7, sint.}: int32
+    of KindAll.x08:
+      x08 {.fieldNumber: 8, sint.}: int64
+    of KindAll.x09:
+      x09 {.fieldNumber: 9, fixed.}: int32
+    of KindAll.x10:
+      x10 {.fieldNumber: 10, fixed.}: int64
+    of KindAll.x11:
+      x11 {.fieldNumber: 11, fixed.}: uint32
+    of KindAll.x12:
+      x12 {.fieldNumber: 12, fixed.}: uint64
+    of KindAll.x13:
+      x13 {.fieldNumber: 13.}: float32
+    of KindAll.x14:
+      x14 {.fieldNumber: 14.}: float64
+
+  ObjAll {.proto3.} = object
+    one {.oneof.}: OneOfAll
+
+suite "Test all types in oneof":
+  test "all oneof unset":
+    let encoded = "".hexToSeqByte
+    let ret = Protobuf.decode(encoded, ObjAll)
+    check:
+      ret.one.kind == KindAll.unset
+      Protobuf.encode(ret) == encoded
+
+  test "string oneof set":
+    let encoded = "0a03616263".hexToSeqByte
+    let ret = Protobuf.decode(encoded, ObjAll)
+    check:
+      ret.one.kind == KindAll.x01
+      ret.one.x01 == "abc"
+      Protobuf.encode(ret) == encoded
+
+  test "bytes oneof set":
+    let encoded = "120101".hexToSeqByte
+    let ret = Protobuf.decode(encoded, ObjAll)
+    check:
+      ret.one.kind == KindAll.x02
+      ret.one.x02 == @[0x01'u8]
+      Protobuf.encode(ret) == encoded
+
+  test "pint int32 oneof set":
+    let encoded = "187b".hexToSeqByte
+    let ret = Protobuf.decode(encoded, ObjAll)
+    check:
+      ret.one.kind == KindAll.x03
+      ret.one.x03 == 123
+      Protobuf.encode(ret) == encoded
+
+  test "sint int32 oneof set":
+    let encoded = "38f601".hexToSeqByte
+    let ret = Protobuf.decode(encoded, ObjAll)
+    check:
+      ret.one.kind == KindAll.x07
+      ret.one.x07 == 123
+      Protobuf.encode(ret) == encoded
+
+  test "fixed int32 oneof set":
+    let encoded = "4d7b000000".hexToSeqByte
+    let ret = Protobuf.decode(encoded, ObjAll)
+    check:
+      ret.one.kind == KindAll.x09
+      ret.one.x09 == 123
+      Protobuf.encode(ret) == encoded

--- a/tests/test_oneof.nim
+++ b/tests/test_oneof.nim
@@ -12,99 +12,115 @@ import stew/byteutils
 import ../protobuf_serialization
 
 type
-  OneOfKind {.pure.} = enum
+  Kind1 {.pure.} = enum
     unset
     x
     y
 
-  OneOfObj {.proto3.} = object
-    one {.oneof, dontSerialize.}: OneOfKind
-    x {.fieldNumber: 1, pint.}: int64
-    y {.fieldNumber: 2, pint.}: int64
+  OneOf1 {.oneof.} = object
+    case kind: Kind1
+    of Kind1.unset:
+      discard
+    of Kind1.x:
+      x {.fieldNumber: 1, pint.}: int64
+    of Kind1.y:
+      y {.fieldNumber: 2, pint.}: int64
+
+  Obj1 {.proto3.} = object
+    one {.oneof.}: OneOf1
 
 suite "Test oneof":
   test "oneof unset":
     let encoded = "".hexToSeqByte
-    check Protobuf.decode(encoded, OneOfObj) == OneOfObj(one: OneOfKind.unset)
+    let ret = Protobuf.decode(encoded, Obj1)
+    check ret.one.kind == Kind1.unset
 
   test "oneof field 1 set":
     # echo 'x: 1' | protoc --encode=OneOfObj test_oneof.proto | hexdump -ve '1/1 "%.2x"'
     # 0801
     let encoded = "0801".hexToSeqByte
-    check Protobuf.decode(encoded, OneOfObj) == OneOfObj(one: OneOfKind.x, x: 1)
+    let ret = Protobuf.decode(encoded, Obj1)
+    check:
+      ret.one.kind == Kind1.x
+      ret.one.x == 1
 
   test "oneof field 2 set":
     let encoded = "1001".hexToSeqByte
-    check Protobuf.decode(encoded, OneOfObj) == OneOfObj(one: OneOfKind.y, y: 1)
+    let ret = Protobuf.decode(encoded, Obj1)
+    check:
+      ret.one.kind == Kind1.y
+      ret.one.y == 1
 
   test "oneof field 1 and 2 set":
     let encoded = "08011001".hexToSeqByte
-    check Protobuf.decode(encoded, OneOfObj) == OneOfObj(one: OneOfKind.y, y: 1)
+    let ret = Protobuf.decode(encoded, Obj1)
+    check:
+      ret.one.kind == Kind1.y
+      ret.one.y == 1
 
   test "oneof field 1 and 2 set variant":
     let encoded = "10010801".hexToSeqByte
-    check Protobuf.decode(encoded, OneOfObj) == OneOfObj(one: OneOfKind.x, x: 1)
+    let ret = Protobuf.decode(encoded, Obj1)
+    check:
+      ret.one.kind == Kind1.x
+      ret.one.x == 1
 
-  test "oneof field 1 and 2 set":
-    let encoded = "0801".hexToSeqByte
-    check Protobuf.encode(OneOfObj(one: OneOfKind.x, x: 1, y: 1)) == encoded
-
-type
-  OneOfKind1 {.pure.} = enum
-    unset
-    a
-    b
-
-  OneOfKind2 {.pure.} = enum
-    unset
-    c
-    d
-
-  OneOfManyObj {.proto3.} = object
-    one {.oneof, dontSerialize.}: OneOfKind1
-    a {.fieldNumber: 1, pint.}: int64
-    b {.fieldNumber: 2, pint.}: int64
-    two {.oneof, dontSerialize.}: OneOfKind2
-    c {.fieldNumber: 3, pint.}: int64
-    d {.fieldNumber: 4, pint.}: int64
-
-suite "Test many oneof":
-  test "many oneof unset":
-    let encoded = "".hexToSeqByte
-    check Protobuf.decode(encoded, OneOfManyObj) ==
-      OneOfManyObj(one: OneOfKind1.unset, two: OneOfKind2.unset)
-
-  test "many oneof field 1 set":
-    let encoded = "0801".hexToSeqByte
-    check Protobuf.decode(encoded, OneOfManyObj) == OneOfManyObj(
-      one: OneOfKind1.a, a: 1
-    )
-    check Protobuf.encode(OneOfManyObj(
-      one: OneOfKind1.a, a: 1
-    )) == encoded
-
-  test "many oneof field 3 set":
-    let encoded = "1801".hexToSeqByte
-    check Protobuf.decode(encoded, OneOfManyObj) == OneOfManyObj(
-      two: OneOfKind2.c, c: 1
-    )
-
-  test "many oneof field 1 and 3 set":
-    let encoded = "08011801".hexToSeqByte
-    check Protobuf.decode(encoded, OneOfManyObj) ==
-      OneOfManyObj(one: OneOfKind1.a, a: 1, two: OneOfKind2.c, c: 1)
-
-  test "many oneof field 1 and 3 set variant":
-    let encoded = "1001200108011801".hexToSeqByte
-    check Protobuf.decode(encoded, OneOfManyObj) ==
-      OneOfManyObj(one: OneOfKind1.a, a: 1, two: OneOfKind2.c, c: 1)
-
-  test "many oneof field 2 and 4 set":
-    let encoded = "10012001".hexToSeqByte
-    check Protobuf.decode(encoded, OneOfManyObj) ==
-      OneOfManyObj(one: OneOfKind1.b, b: 1, two: OneOfKind2.d, d: 1)
-
-  test "many oneof field 2 and 4 set variant":
-    let encoded = "0801180110012001".hexToSeqByte
-    check Protobuf.decode(encoded, OneOfManyObj) ==
-      OneOfManyObj(one: OneOfKind1.b, b: 1, two: OneOfKind2.d, d: 1)
+#type
+#  OneOfKind1 {.pure.} = enum
+#    unset
+#    a
+#    b
+#
+#  OneOfKind2 {.pure.} = enum
+#    unset
+#    c
+#    d
+#
+#  OneOfManyObj {.proto3.} = object
+#    one {.oneof, dontSerialize.}: OneOfKind1
+#    a {.fieldNumber: 1, pint.}: int64
+#    b {.fieldNumber: 2, pint.}: int64
+#    two {.oneof, dontSerialize.}: OneOfKind2
+#    c {.fieldNumber: 3, pint.}: int64
+#    d {.fieldNumber: 4, pint.}: int64
+#
+#suite "Test many oneof":
+#  test "many oneof unset":
+#    let encoded = "".hexToSeqByte
+#    check Protobuf.decode(encoded, OneOfManyObj) ==
+#      OneOfManyObj(one: OneOfKind1.unset, two: OneOfKind2.unset)
+#
+#  test "many oneof field 1 set":
+#    let encoded = "0801".hexToSeqByte
+#    check Protobuf.decode(encoded, OneOfManyObj) == OneOfManyObj(
+#      one: OneOfKind1.a, a: 1
+#    )
+#    check Protobuf.encode(OneOfManyObj(
+#      one: OneOfKind1.a, a: 1
+#    )) == encoded
+#
+#  test "many oneof field 3 set":
+#    let encoded = "1801".hexToSeqByte
+#    check Protobuf.decode(encoded, OneOfManyObj) == OneOfManyObj(
+#      two: OneOfKind2.c, c: 1
+#    )
+#
+#  test "many oneof field 1 and 3 set":
+#    let encoded = "08011801".hexToSeqByte
+#    check Protobuf.decode(encoded, OneOfManyObj) ==
+#      OneOfManyObj(one: OneOfKind1.a, a: 1, two: OneOfKind2.c, c: 1)
+#
+#  test "many oneof field 1 and 3 set variant":
+#    let encoded = "1001200108011801".hexToSeqByte
+#    check Protobuf.decode(encoded, OneOfManyObj) ==
+#      OneOfManyObj(one: OneOfKind1.a, a: 1, two: OneOfKind2.c, c: 1)
+#
+#  test "many oneof field 2 and 4 set":
+#    let encoded = "10012001".hexToSeqByte
+#    check Protobuf.decode(encoded, OneOfManyObj) ==
+#      OneOfManyObj(one: OneOfKind1.b, b: 1, two: OneOfKind2.d, d: 1)
+#
+#  test "many oneof field 2 and 4 set variant":
+#    let encoded = "0801180110012001".hexToSeqByte
+#    check Protobuf.decode(encoded, OneOfManyObj) ==
+#      OneOfManyObj(one: OneOfKind1.b, b: 1, two: OneOfKind2.d, d: 1)

--- a/tests/test_oneof.nim
+++ b/tests/test_oneof.nim
@@ -354,3 +354,51 @@ suite "Test all types in oneof":
       ret.one.kind == KindAll.x15
       ret.one.x15 == SomeMessage(y: 1)
       Protobuf.encode(ret) == "7a021001".hexToSeqByte
+
+  test "oneof unknown type won't set it":
+    # echo "0801" | xxd -r -p | protoc --decode=ObjAll test_oneof.proto
+    # 1: 1
+    let encoded = "0801".hexToSeqByte
+    let ret = Protobuf.decode(encoded, ObjAll)
+    check:
+      ret.one.kind == KindAll.unset
+      Protobuf.encode(ret) == "".hexToSeqByte
+
+  test "oneof unknown type won't overwrite previous set":
+    # echo "0a036162630801" | xxd -r -p | protoc --decode=ObjAll test_oneof.proto
+    # x01: "abc"
+    # 1: 1
+    let encoded = "0a036162630801".hexToSeqByte
+    let ret = Protobuf.decode(encoded, ObjAll)
+    check:
+      ret.one.kind == KindAll.x01
+      ret.one.x01 == "abc"
+      Protobuf.encode(ret) == "0a03616263".hexToSeqByte
+
+  test "oneof unknown type variant":
+    # echo "08010a036162630801" | xxd -r -p | protoc --decode=ObjAll test_oneof.proto
+    # x01: "abc"
+    # 1: 1
+    # 1: 1
+    let encoded = "0a036162630801".hexToSeqByte
+    let ret = Protobuf.decode(encoded, ObjAll)
+    check:
+      ret.one.kind == KindAll.x01
+      ret.one.x01 == "abc"
+      Protobuf.encode(ret) == "0a03616263".hexToSeqByte
+
+  test "oneof unknown type variant 2":
+    # 7a020801 -> x15: {x: 1}
+    # 0801 -> 1: 1
+    # 7a021001 -> x15: {y: 1}
+    # echo "7a02080108017a021001" | xxd -r -p | protoc --decode=ObjAll test_oneof.proto
+    # x15 {
+    #   x: 1
+    #   y: 1
+    # }
+    let encoded = "7a02080108017a021001".hexToSeqByte
+    let ret = Protobuf.decode(encoded, ObjAll)
+    check:
+      ret.one.kind == KindAll.x15
+      ret.one.x15 == SomeMessage(x: 1, y: 1)
+      Protobuf.encode(ret) == "7a0408011001".hexToSeqByte

--- a/tests/test_oneof.nim
+++ b/tests/test_oneof.nim
@@ -33,7 +33,9 @@ suite "Test oneof":
   test "oneof unset":
     let encoded = "".hexToSeqByte
     let ret = Protobuf.decode(encoded, Obj1)
-    check ret.one.kind == Kind1.unset
+    check:
+      ret.one.kind == Kind1.unset
+      Protobuf.encode(ret) == encoded
 
   test "oneof field 1 set":
     # echo 'x: 1' | protoc --encode=OneOfObj test_oneof.proto | hexdump -ve '1/1 "%.2x"'
@@ -43,6 +45,7 @@ suite "Test oneof":
     check:
       ret.one.kind == Kind1.x
       ret.one.x == 1
+      Protobuf.encode(ret) == encoded
 
   test "oneof field 2 set":
     let encoded = "1001".hexToSeqByte
@@ -50,6 +53,7 @@ suite "Test oneof":
     check:
       ret.one.kind == Kind1.y
       ret.one.y == 1
+      Protobuf.encode(ret) == encoded
 
   test "oneof field 1 and 2 set":
     let encoded = "08011001".hexToSeqByte
@@ -65,62 +69,81 @@ suite "Test oneof":
       ret.one.kind == Kind1.x
       ret.one.x == 1
 
-#type
-#  OneOfKind1 {.pure.} = enum
-#    unset
-#    a
-#    b
-#
-#  OneOfKind2 {.pure.} = enum
-#    unset
-#    c
-#    d
-#
-#  OneOfManyObj {.proto3.} = object
-#    one {.oneof, dontSerialize.}: OneOfKind1
-#    a {.fieldNumber: 1, pint.}: int64
-#    b {.fieldNumber: 2, pint.}: int64
-#    two {.oneof, dontSerialize.}: OneOfKind2
-#    c {.fieldNumber: 3, pint.}: int64
-#    d {.fieldNumber: 4, pint.}: int64
-#
-#suite "Test many oneof":
-#  test "many oneof unset":
-#    let encoded = "".hexToSeqByte
-#    check Protobuf.decode(encoded, OneOfManyObj) ==
-#      OneOfManyObj(one: OneOfKind1.unset, two: OneOfKind2.unset)
-#
-#  test "many oneof field 1 set":
-#    let encoded = "0801".hexToSeqByte
-#    check Protobuf.decode(encoded, OneOfManyObj) == OneOfManyObj(
-#      one: OneOfKind1.a, a: 1
-#    )
-#    check Protobuf.encode(OneOfManyObj(
-#      one: OneOfKind1.a, a: 1
-#    )) == encoded
-#
-#  test "many oneof field 3 set":
-#    let encoded = "1801".hexToSeqByte
-#    check Protobuf.decode(encoded, OneOfManyObj) == OneOfManyObj(
-#      two: OneOfKind2.c, c: 1
-#    )
-#
-#  test "many oneof field 1 and 3 set":
-#    let encoded = "08011801".hexToSeqByte
-#    check Protobuf.decode(encoded, OneOfManyObj) ==
-#      OneOfManyObj(one: OneOfKind1.a, a: 1, two: OneOfKind2.c, c: 1)
-#
-#  test "many oneof field 1 and 3 set variant":
-#    let encoded = "1001200108011801".hexToSeqByte
-#    check Protobuf.decode(encoded, OneOfManyObj) ==
-#      OneOfManyObj(one: OneOfKind1.a, a: 1, two: OneOfKind2.c, c: 1)
-#
-#  test "many oneof field 2 and 4 set":
-#    let encoded = "10012001".hexToSeqByte
-#    check Protobuf.decode(encoded, OneOfManyObj) ==
-#      OneOfManyObj(one: OneOfKind1.b, b: 1, two: OneOfKind2.d, d: 1)
-#
-#  test "many oneof field 2 and 4 set variant":
-#    let encoded = "0801180110012001".hexToSeqByte
-#    check Protobuf.decode(encoded, OneOfManyObj) ==
-#      OneOfManyObj(one: OneOfKind1.b, b: 1, two: OneOfKind2.d, d: 1)
+type
+  OneOf2 {.oneof.} = object
+    case kind: Kind1
+    of Kind1.unset:
+      discard
+    of Kind1.x:
+      x {.fieldNumber: 3, pint.}: int64
+    of Kind1.y:
+      y {.fieldNumber: 4, pint.}: int64
+
+  Obj2 {.proto3.} = object
+    one {.oneof.}: OneOf1
+    two {.oneof.}: OneOf2
+
+suite "Test many oneof":
+  test "many oneof unset":
+    let encoded = "".hexToSeqByte
+    let ret = Protobuf.decode(encoded, Obj2)
+    check:
+      ret.one.kind == Kind1.unset
+      ret.two.kind == Kind1.unset
+      Protobuf.encode(ret) == encoded
+
+  test "many oneof field 1 set":
+    let encoded = "0801".hexToSeqByte
+    let ret = Protobuf.decode(encoded, Obj2)
+    check:
+      ret.one.kind == Kind1.x
+      ret.one.x == 1
+      ret.two.kind == Kind1.unset
+      Protobuf.encode(ret) == encoded
+
+  test "many oneof field 3 set":
+    let encoded = "1801".hexToSeqByte
+    let ret = Protobuf.decode(encoded, Obj2)
+    check:
+      ret.one.kind == Kind1.unset
+      ret.two.kind == Kind1.x
+      ret.two.x == 1
+      Protobuf.encode(ret) == encoded
+
+  test "many oneof field 1 and 3 set":
+    let encoded = "08011801".hexToSeqByte
+    let ret = Protobuf.decode(encoded, Obj2)
+    check:
+      ret.one.kind == Kind1.x
+      ret.one.x == 1
+      ret.two.kind == Kind1.x
+      ret.two.x == 1
+      Protobuf.encode(ret) == encoded
+
+  test "many oneof field 1 and 3 set variant":
+    let encoded = "1001200108011801".hexToSeqByte
+    let ret = Protobuf.decode(encoded, Obj2)
+    check:
+      ret.one.kind == Kind1.x
+      ret.one.x == 1
+      ret.two.kind == Kind1.x
+      ret.two.x == 1
+
+  test "many oneof field 2 and 4 set":
+    let encoded = "10012001".hexToSeqByte
+    let ret = Protobuf.decode(encoded, Obj2)
+    check:
+      ret.one.kind == Kind1.y
+      ret.one.y == 1
+      ret.two.kind == Kind1.y
+      ret.two.y == 1
+      Protobuf.encode(ret) == encoded
+
+  test "many oneof field 2 and 4 set variant":
+    let encoded = "0801180110012001".hexToSeqByte
+    let ret = Protobuf.decode(encoded, Obj2)
+    check:
+      ret.one.kind == Kind1.y
+      ret.one.y == 1
+      ret.two.kind == Kind1.y
+      ret.two.y == 1

--- a/tests/test_oneof.proto
+++ b/tests/test_oneof.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+
+message OneOfObj {
+  int64 x = 1;
+  int64 y = 2;
+}

--- a/tests/test_oneof.proto
+++ b/tests/test_oneof.proto
@@ -4,3 +4,17 @@ message OneOfObj {
   int64 x = 1;
   int64 y = 2;
 }
+
+message SomeMessage {
+  int32 x = 1;
+  int32 y = 2;
+}
+
+message ObjAll {
+  oneof one {
+    string x01 = 1;
+    int32 x03 = 3;
+    SomeMessage x15 = 15;
+  }
+}
+


### PR DESCRIPTION
Fixes #15

Changes:

- Implement `Oneof` field
- Conformance tests
- import_proto3 code gen

HEAD:

```
CONFORMANCE SUITE PASSED: 1321 successes, 1367 skipped, 41 expected failures, 0 unexpected failures.
```

This PR:

```
CONFORMANCE SUITE PASSED: 1363 successes, 1367 skipped, 24 expected failures, 0 unexpected failures.
```