### PR TITLE
Fix header varint read

### DIFF
--- a/protobuf_serialization/codec.nim
+++ b/protobuf_serialization/codec.nim
@@ -123,7 +123,6 @@ template toUleb(x: pint32): uint64 = cast[uint64](int64(x))
 template toUleb(x: pbool): uint8 = cast[uint8](x)
 template toUleb(x: penum): uint64 = cast[uint32](x)
 
-template fromUleb(x: uint64, T: type puint64): T = puint64(x)
 template fromUleb(x: uint64, T: type pbool): T = pbool(x != 0)
 
 template fromUleb(x: uint64, T: type puint64): T = puint64(x)
@@ -283,7 +282,7 @@ proc skipValue*[T: SomeLengthDelim](input: InputStream, _: type T) {.raises: [Se
 
 proc readHeader*(input: InputStream): FieldHeader {.raises: [SerializationError, IOError].} =
   let
-    hdr = uint32(input.readValue(puint32))
+    hdr = input.readVarint(uint32)
     wire = uint8(hdr and 0x07)
 
   if wire in GroupWireKinds:

--- a/protobuf_serialization/internal.nim
+++ b/protobuf_serialization/internal.nim
@@ -12,7 +12,7 @@ export hasCustomPragmaFixed
 
 import serialization
 
-import "."/[codec, types]
+import ./[codec, types]
 
 type UnsupportedType*[FieldType; RootType; fieldName: static string] = object
 

--- a/protobuf_serialization/reader.nim
+++ b/protobuf_serialization/reader.nim
@@ -9,7 +9,7 @@ import
   stew/shims/macros,
   faststreams/inputs,
   serialization,
-  "."/[codec, internal, types]
+  ./[codec, internal, types]
 
 export inputs, serialization, codec, types
 

--- a/protobuf_serialization/sizer.nim
+++ b/protobuf_serialization/sizer.nim
@@ -4,7 +4,7 @@ import
   std/[typetraits],
   stew/shims/macros,
   serialization,
-  "."/[codec, internal, types]
+  ./[codec, internal, types]
 
 func computeObjectSize*[T: object](value: T): int
 
@@ -54,12 +54,6 @@ when defined(ConformanceTest):
       computeFieldSize(fieldNum, fieldVal[], ProtoType, skipDefault)
     else:
       0
-
-  proc writeField[T: enum](
-      stream: OutputStream, fieldNum: int, fieldVal: T, ProtoType: type) =
-    when 0 notin T:
-      {.fatal: $T & " definition must contain a constant that maps to zero".}
-    stream.writeField(fieldNum, pint32(fieldVal.ord()))
 
 proc computeSizePacked*[T: not byte, ProtoType: SomePrimitive](
     values: openArray[T], _: type ProtoType): int =

--- a/protobuf_serialization/writer.nim
+++ b/protobuf_serialization/writer.nim
@@ -8,7 +8,7 @@ import
   stew/objects,
   faststreams/outputs,
   serialization,
-  "."/[codec, internal, sizer, types]
+  ./[codec, internal, sizer, types]
 
 export outputs, serialization, codec, types
 

--- a/tests/test_malformed.nim
+++ b/tests/test_malformed.nim
@@ -56,6 +56,13 @@ suite "Test well formed messages":
     let encoded = "08FFFFFFFFFFFFFFFF7F".hexToSeqByte
     check ProtoBuf.decode(encoded, Varint) == Varint(x: int64.high)
 
+  test "Header varint 5 bytes (non-canonical)":
+    # echo "8A8080800001FF" | xxd -r -p | protoc --decode=Bytes test_malformed.proto
+    # x: "\377"
+    # echo 'x: "\377"' | protoc --encode=Bytes test_malformed.proto | hexdump -ve '1/1 "%.2x"'
+    let encoded = "8A8080800001FF".hexToSeqByte
+    check ProtoBuf.decode(encoded, Bytes) == Bytes(x: @[255.byte])
+
 suite "Test malformed messages":
   test "Max uint32 + 1 length":
     # echo "0A8080808010" | xxd -r -p | protoc --decode=Bytes test_malformed.proto
@@ -187,3 +194,19 @@ suite "Test malformed messages":
     let encoded = "0901000000000000".hexToSeqByte
     expect(ProtobufValueError):
       discard Protobuf.decode(encoded, FixedInt64Obj)
+
+  test "Header varint 10 bytes":
+    # echo "8A80808080808080800001FF" | xxd -r -p | protoc --decode=Bytes test_malformed.proto
+    # Failed to parse input.
+    # If the header varint is read as uint64, the value is 0x0A == field 1; type 2 (valid)
+    let encoded = "8A80808080808080800001FF".hexToSeqByte
+    expect(ProtobufValueError):
+      discard ProtoBuf.decode(encoded, Bytes)
+
+  test "Header varint max uint64":
+    # echo "FFFFFFFFFFFFFFFFFF0100" | xxd -r -p | protoc --decode=Bytes test_malformed.proto
+    # Failed to parse input.
+    let encoded = "FFFFFFFFFFFFFFFFFF0100".hexToSeqByte
+    # XXX check it throws varint read error; not wrong wire type
+    expect(ProtobufValueError):
+      discard ProtoBuf.decode(encoded, Bytes)


### PR DESCRIPTION
Changes:

- Read header varint as uint32; avoid truncation
- Malformed data tests
- minor import, and dead code cleanups