### PR TITLE
Return whether the field is known in `readFieldInto`

### DIFF
--- a/protobuf_serialization/codec.nim
+++ b/protobuf_serialization/codec.nim
@@ -75,6 +75,8 @@ type
   SomePrimitive* = SomeVarint | SomeFixed64 | SomeFixed32
     ## Types that may appear packed
 
+  SomeProto* = SomeVarint | SomeFixed64 | SomeLengthDelim | SomeFixed32
+
 const
   GroupWireKinds = {
     3'u8, 4'u8  # StartGroup, EndGroup

--- a/protobuf_serialization/reader.nim
+++ b/protobuf_serialization/reader.nim
@@ -15,105 +15,112 @@ export inputs, serialization, codec, types
 
 proc readValueInternal[T: object](stream: InputStream, value: var T, silent: bool = false) {.raises: [SerializationError, IOError].}
 
-macro unsupported(T: typed): untyped =
-  error "Assignment of the type " & humaneTypeName(T) & " is not supported"
-
-proc readFieldInto[T: object](
+proc readFieldInto*[T: not seq and not PBOption](
   stream: InputStream,
   value: var T,
   header: FieldHeader,
-  ProtoType: type
-) {.raises: [SerializationError, IOError].} =
-  doAssert header.kind() == WireKind.LengthDelim
+  ProtoType: type UnsupportedType
+): bool {.raises: [SerializationError, IOError].} =
+  unsupportedProtoType ProtoType.FieldType, ProtoType.RootType, ProtoType.fieldName
 
-  let len = stream.readLength()
-  if len > 0:
-    # TODO: https://github.com/status-im/nim-faststreams/issues/31
-    # TODO: check that all bytes were read
-    # stream.withReadableRange(len, inner):
-    #   inner.readValueInternal(value)
+proc readFieldInto*[T: object and not PBOption](
+  stream: InputStream,
+  value: var T,
+  header: FieldHeader,
+  ProtoType: type pbytes
+): bool {.raises: [SerializationError, IOError].} =
+  if header.kind() == WireKind.LengthDelim:
+    let len = stream.readLength()
+    if len > 0:
+      # TODO: https://github.com/status-im/nim-faststreams/issues/31
+      # TODO: check that all bytes were read
+      # stream.withReadableRange(len, inner):
+      #   inner.readValueInternal(value)
 
-    let inputLen = stream.len()
-    if inputLen.isSome() and len > inputLen.get():
-      raise (ref ProtobufValueError)(msg: "Missing bytes: " & $len)
+      let inputLen = stream.len()
+      if inputLen.isSome() and len > inputLen.get():
+        raise (ref ProtobufValueError)(msg: "Missing bytes: " & $len)
 
-    var tmp = newSeqUninitialized[byte](len)
-    if not stream.readInto(tmp):
-      raise (ref ProtobufValueError)(msg: "not enough bytes")
-    memoryInput(tmp).readValueInternal(value)
+      var tmp = newSeqUninitialized[byte](len)
+      if not stream.readInto(tmp):
+        raise (ref ProtobufValueError)(msg: "not enough bytes")
+      memoryInput(tmp).readValueInternal(value)
+    true
+  else:
+    false
 
 when defined(ConformanceTest):
-  proc readFieldInto[T: enum](
+  proc readFieldInto*[T: enum](
     stream: InputStream,
     value: var T,
     header: FieldHeader,
     ProtoType: type
-  ) {.raises: [SerializationError, IOError].} =
+  ): bool {.raises: [SerializationError, IOError].} =
     # TODO: This function doesn't work for proto2 edge cases. Make it work
     when 0 notin T and T.isProto3():
       {.fatal: $T & " definition must contain a constant that maps to zero".}
-    doAssert header.kind() == WireKind.Varint
-    let enumValue = stream.readValue(ProtoType)
-    if not checkedEnumAssign(value, enumValue.int32):
-      discard checkedEnumAssign(value, 0)
+    if header.kind() == WireKind.Varint:
+      let enumValue = stream.readValue(ProtoType)
+      if not checkedEnumAssign(value, enumValue.int32):
+        discard checkedEnumAssign(value, 0)
+      true
+    else:
+      false
 
-proc readFieldInto[T: not object and not enum and (seq[byte] or not seq)](
+proc readFieldInto*[T: not object and not enum and (seq[byte] or not seq)](
   stream: InputStream,
   value: var T,
   header: FieldHeader,
-  ProtoType: type
-) {.raises: [SerializationError, IOError].} =
-  doAssert header.kind() == wireKind(ProtoType)
-  when ProtoType is SomeVarint:
-    assign(value, T(stream.readValue(ProtoType)))
-  elif ProtoType is SomeFixed64:
-    assign(value, T(stream.readValue(ProtoType)))
-  elif ProtoType is SomeLengthDelim:
-    assign(value, T(stream.readValue(ProtoType)))
-  elif ProtoType is SomeFixed32:
-    assign(value, T(stream.readValue(ProtoType)))
+  ProtoType: type SomeProto
+): bool {.raises: [SerializationError, IOError].} =
+  if header.kind() == wireKind(ProtoType):
+    when ProtoType is SomeVarint:
+      assign(value, T(stream.readValue(ProtoType)))
+    elif ProtoType is SomeFixed64:
+      assign(value, T(stream.readValue(ProtoType)))
+    elif ProtoType is SomeLengthDelim:
+      assign(value, T(stream.readValue(ProtoType)))
+    else:
+      static: doAssert ProtoType is SomeFixed32
+      assign(value, T(stream.readValue(ProtoType)))
+    true
   else:
-    static: unsupported(ProtoType)
+    false
 
-proc readFieldInto[T: not byte](
+proc readFieldInto*[T: not byte](
   stream: InputStream,
   value: var seq[T],
   header: FieldHeader,
   ProtoType: type
-) {.raises: [SerializationError, IOError].} =
+): bool {.raises: [SerializationError, IOError].} =
   value.add(default(T))
   stream.readFieldInto(value[^1], header, ProtoType)
 
-proc readFieldInto(
+proc readFieldInto*(
   stream: InputStream,
   value: var PBOption,
   header: FieldHeader,
   ProtoType: type
-) {.raises: [SerializationError, IOError].} =
+): bool {.raises: [SerializationError, IOError].} =
   stream.readFieldInto(value.mget(), header, ProtoType)
 
-proc readFieldPackedInto[T](
+proc readFieldPackedInto*[T](
   stream: InputStream,
   value: var seq[T],
   header: FieldHeader,
-  ProtoType: type
-) {.raises: [SerializationError, IOError].} =
+  ProtoType: type SomePrimitive
+): bool {.raises: [SerializationError, IOError].} =
   # TODO make more efficient
+  doAssert header.kind() == WireKind.LengthDelim
   var
     bytes = seq[byte](stream.readValue(pbytes))
     inner = memoryInput(bytes)
+    headerElm = FieldHeader.init(header.number, wireKind(ProtoType))
   while inner.readable():
     value.add(default(T))
-
-    let kind = when ProtoType is SomeVarint:
-      WireKind.Varint
-    elif ProtoType is SomeFixed32:
-      WireKind.Fixed32
-    else:
-      static: doAssert ProtoType is SomeFixed64
-      WireKind.Fixed64
-
-    inner.readFieldInto(value[^1], FieldHeader.init(header.number, kind), ProtoType)
+    let r = inner.readFieldInto(value[^1], headerElm, ProtoType)
+    doAssert r
+  true
 
 proc readValueInternal[T: object](stream: InputStream, value: var T, silent: bool = false) {.raises: [SerializationError, IOError].} =
   const
@@ -145,21 +152,16 @@ proc readValueInternal[T: object](stream: InputStream, value: var T, silent: boo
       if header.number() == fieldNum:
         protoType(ProtoType, T, typeof(fieldVar), fieldName)
         # TODO should we allow reading packed fields into non-repeated fields?
-        when ProtoType is SomePrimitive and fieldVar is seq and fieldVar isnot seq[byte]:
-          if header.kind() == WireKind.LengthDelim:
-            knownField = true
-            stream.readFieldPackedInto(fieldVar, header, ProtoType)
-          elif header.kind() == wireKind(ProtoType):
-            knownField = true
-            stream.readFieldInto(fieldVar, header, ProtoType)
-        elif typeof(fieldVar) is ref and defined(ConformanceTest):
-          if header.kind() == wireKind(ProtoType):
-            knownField = true
+        knownField =
+          when ProtoType is SomePrimitive and fieldVar is seq and fieldVar isnot seq[byte]:
+            if header.kind() == WireKind.LengthDelim:
+              stream.readFieldPackedInto(fieldVar, header, ProtoType)
+            else:
+              stream.readFieldInto(fieldVar, header, ProtoType)
+          elif typeof(fieldVar) is ref and defined(ConformanceTest):
             fieldVar = new typeof(fieldVar)
             stream.readFieldInto(fieldVar[], header, ProtoType)
-        else:
-          if header.kind() == wireKind(ProtoType):
-            knownField = true
+          else:
             stream.readFieldInto(fieldVar, header, ProtoType)
 
         when isProto2:


### PR DESCRIPTION
Changes:

- Change `readFieldInto` signature to return `bool`; Return `true` if the field is known (consumed from the wire), otherwise `false`

This is to prepare for the extension system; we don't know if the wire type is the one the extension expects or not; the alternative is to add yet another overload to check the wire type is ok before calling `readFieldInto`.