### PR TITLE
Fix: do not set `PBOption` if wire type is unexpected

### DIFF
--- a/protobuf_serialization/reader.nim
+++ b/protobuf_serialization/reader.nim
@@ -102,7 +102,11 @@ proc readFieldInto*(
   header: FieldHeader,
   ProtoType: type
 ): bool {.raises: [SerializationError, IOError].} =
-  stream.readFieldInto(value.mget(), header, ProtoType)
+  if stream.readFieldInto(value.mget(), header, ProtoType):
+    true
+  else:
+    reset(value)
+    false
 
 proc readFieldPackedInto*[T](
   stream: InputStream,

--- a/tests/test_protobuf2_semantics.nim
+++ b/tests/test_protobuf2_semantics.nim
@@ -52,60 +52,60 @@ suite "Test Encoding of Protobuf 2 Semantics":
       opt.get() == false
 
   test "Encodes required":
-    check Protobuf.encode(Required(b: 0'i32)).len == 2
+    # echo 'b: 0' | protoc --encode=Required test_protobuf2_semantics.proto | hexdump -ve '1/1 "%.2x"'
+    # 1000
+    roundtrip(Required(b: 0'i32), "1000")
 
   test "Encodes set":
-    check Protobuf.encode(Required(a: pbSome(type(Required.a), 0'i32), b: 0'i32)).len == 4
+    # echo 'a: 0 b: 0' | protoc --encode=Required test_protobuf2_semantics.proto | hexdump -ve '1/1 "%.2x"'
+    # 08001000
+    roundtrip(Required(a: PBOption[2'i32].pbSome(0'i32), b: 0'i32), "08001000")
 
   test "Requires required":
     expect ProtobufReadError:
       discard Protobuf.decode(default(seq[byte]), Required)
 
   test "Handles default":
-    var fod: FullOfDefaults = FullOfDefaults(b: PBOption[default(Required)].pbSome(Required(b: 5)))
+    # echo 'b: 0' | protoc --encode=Required test_protobuf2_semantics.proto | hexdump -ve '1/1 "%.2x"'
+    # 1000
+    roundtrip(Required(), "1000")
+    # echo 'b: { b: 5 }' | protoc --encode=FullOfDefaults test_protobuf2_semantics.proto | hexdump -ve '1/1 "%.2x"'
+    # 22021005
+    roundtrip(FullOfDefaults(b: pbSome(Required(b: 5))), "22021005")
     check:
-      Protobuf.decode(Protobuf.encode(Required()), Required).a.isNone()
-      Protobuf.decode(Protobuf.encode(Required()), Required).a.get() == 2
-
-      Protobuf.decode(Protobuf.encode(fod), FullOfDefaults).a.isNone()
-      Protobuf.decode(Protobuf.encode(fod), FullOfDefaults).a.get() == "abc"
-
-      Protobuf.decode(Protobuf.encode(fod), FullOfDefaults).b.isSome()
-      Protobuf.decode(Protobuf.encode(fod), FullOfDefaults).b.get().a.get() == 2'i32
+      # PBOption is isNone when field is absent; get() returns the type default, not unset
+      Protobuf.decode("1000".hexToSeqByte, Required).a.isNone()
+      Protobuf.decode("1000".hexToSeqByte, Required).a.get() == 2
+      Protobuf.decode("22021005".hexToSeqByte, FullOfDefaults).a.isNone()
+      Protobuf.decode("22021005".hexToSeqByte, FullOfDefaults).a.get() == "abc"
+      Protobuf.decode("22021005".hexToSeqByte, FullOfDefaults).b.isSome()
+      Protobuf.decode("22021005".hexToSeqByte, FullOfDefaults).b.get().a.get() == 2'i32
 
   test "Doesn't require Option for seq":
-    check Protobuf.decode(Protobuf.encode(SeqContainer()), SeqContainer).data.len == 0
+    roundtrip(SeqContainer(), "")
 
   test "Can encode a seq[string] correctly":
-    var ssb: SeqString = SeqString()
-    check Protobuf.decode(Protobuf.encode(ssb), SeqString) == ssb
-    ssb = SeqString(data: newSeq[string](0))
-    check Protobuf.decode(Protobuf.encode(ssb), SeqString) == ssb
-    ssb = SeqString(data: newSeq[string](1))
-    check Protobuf.decode(Protobuf.encode(ssb), SeqString) == ssb
-    ssb = SeqString(data: @["abc"])
-    check Protobuf.decode(Protobuf.encode(ssb), SeqString) == ssb
-    ssb = SeqString(data: @["abc", "def"])
-    check Protobuf.decode(Protobuf.encode(ssb), SeqString) == ssb
-    ssb = SeqString(data: @["abc", "def", ""])
-    check Protobuf.decode(Protobuf.encode(ssb), SeqString) == ssb
-    ssb = SeqString(data: @["abc", "def", "ghi"])
-    check Protobuf.decode(Protobuf.encode(ssb), SeqString) == ssb
+    roundtrip(SeqString(), "")
+    # echo 'data: ""' | protoc --encode=SeqString test_protobuf2_semantics.proto | hexdump -ve '1/1 "%.2x"'
+    # 3200
+    roundtrip(SeqString(data: @[""]), "3200")
+    # echo 'data: "abc"' | protoc --encode=SeqString test_protobuf2_semantics.proto | hexdump -ve '1/1 "%.2x"'
+    # 3203616263
+    roundtrip(SeqString(data: @["abc"]), "3203616263")
+    # echo 'data: "abc" data: "def"' | protoc --encode=SeqString test_protobuf2_semantics.proto | hexdump -ve '1/1 "%.2x"'
+    roundtrip(SeqString(data: @["abc", "def"]), "32036162633203646566")
+    roundtrip(SeqString(data: @["abc", "def", ""]), "320361626332036465663200")
+    roundtrip(SeqString(data: @["abc", "def", "ghi"]), "320361626332036465663203676869")
 
   test "Option[Float] in object":
-    var x = FloatOption(x: PBOption[0'f32].pbSome(1.5'f32))
-    check Protobuf.decode(Protobuf.encode(x), FloatOption) == x
-
-    var y = FloatOption(y: PBOption[0'f64].pbSome(1.3'f64))
-    check Protobuf.decode(Protobuf.encode(y), FloatOption) == y
-
-    var z = FloatOption(
-      x: PBOption[0'f32].pbSome(1.5'f32),
-      y: PBOption[0'f64].pbSome(1.3'f64))
-    check Protobuf.decode(Protobuf.encode(z), FloatOption) == z
-
-    var v = FloatOption()
-    check Protobuf.decode(Protobuf.encode(v), FloatOption) == v
+    # echo 'x: 1.5' | protoc --encode=FloatOption test_protobuf2_semantics.proto | hexdump -ve '1/1 "%.2x"'
+    # 0d0000c03f
+    roundtrip(FloatOption(x: pbSome(1.5'f32)), "0d0000c03f")
+    # echo 'y: 1.3' | protoc --encode=FloatOption test_protobuf2_semantics.proto | hexdump -ve '1/1 "%.2x"'
+    # 11cdccccccccccf43f
+    roundtrip(FloatOption(y: pbSome(1.3'f64)), "11cdccccccccccf43f")
+    roundtrip(FloatOption(x: pbSome(1.5'f32), y: pbSome(1.3'f64)), "0d0000c03f11cdccccccccccf43f")
+    roundtrip(FloatOption(), "")
 
   test "Option[Fixed] in object":
     # echo "0d01000000" | xxd -r -p | protoc --decode=FixedOption test_protobuf2_semantics.proto

--- a/tests/test_protobuf2_semantics.nim
+++ b/tests/test_protobuf2_semantics.nim
@@ -119,7 +119,7 @@ suite "Test Encoding of Protobuf 2 Semantics":
     # echo "0801" | xxd -r -p | protoc --decode=FixedOption test_protobuf2_semantics.proto
     # 1: 1
     let encoded = "0801".hexToSeqByte
-    check ProtoBuf.decode(encoded, FixedOption) == FixedOption()
+    check Protobuf.decode(encoded, FixedOption) == FixedOption()
 
   test "pbSome ergonomic":
     check:

--- a/tests/test_protobuf2_semantics.nim
+++ b/tests/test_protobuf2_semantics.nim
@@ -115,7 +115,7 @@ suite "Test Encoding of Protobuf 2 Semantics":
     roundtrip(FixedOption(c: pbSome(1'u32)), "1d01000000")
     roundtrip(FixedOption(d: pbSome(1'u64)), "210100000000000000")
 
-  test "invalid type does not set PBOption":
+  test "unexpected type does not set PBOption":
     # echo "0801" | xxd -r -p | protoc --decode=FixedOption test_protobuf2_semantics.proto
     # 1: 1
     let encoded = "0801".hexToSeqByte

--- a/tests/test_protobuf2_semantics.nim
+++ b/tests/test_protobuf2_semantics.nim
@@ -7,9 +7,11 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-import unittest2
-
-import ../protobuf_serialization
+import
+  unittest2,
+  stew/byteutils,
+  ./utils,
+  ../protobuf_serialization
 
 type
   Required {.proto2.} = object
@@ -106,17 +108,18 @@ suite "Test Encoding of Protobuf 2 Semantics":
     check Protobuf.decode(Protobuf.encode(v), FloatOption) == v
 
   test "Option[Fixed] in object":
-    var x = FixedOption(a: PBOption[0'i32].pbSome(1'i32))
-    check Protobuf.decode(Protobuf.encode(x), FixedOption) == x
+    # echo "0d01000000" | xxd -r -p | protoc --decode=FixedOption test_protobuf2_semantics.proto
+    # echo 'a: 1' | protoc --encode=FixedOption test_protobuf2_semantics.proto | hexdump -ve '1/1 "%.2x"'
+    roundtrip(FixedOption(a: pbSome(1'i32)), "0d01000000")
+    roundtrip(FixedOption(b: pbSome(1'i64)), "110100000000000000")
+    roundtrip(FixedOption(c: pbSome(1'u32)), "1d01000000")
+    roundtrip(FixedOption(d: pbSome(1'u64)), "210100000000000000")
 
-    var y = FixedOption(b: PBOption[0'i64].pbSome(1'i64))
-    check Protobuf.decode(Protobuf.encode(y), FixedOption) == y
-
-    var z = FixedOption(c: PBOption[0'u32].pbSome(1'u32))
-    check Protobuf.decode(Protobuf.encode(z), FixedOption) == z
-
-    var v = FixedOption(d: PBOption[0'u64].pbSome(1'u64))
-    check Protobuf.decode(Protobuf.encode(v), FixedOption) == v
+  test "invalid type does not set PBOption":
+    # echo "0801" | xxd -r -p | protoc --decode=FixedOption test_protobuf2_semantics.proto
+    # 1: 1
+    let encoded = "0801".hexToSeqByte
+    check ProtoBuf.decode(encoded, FixedOption) == FixedOption()
 
   test "pbSome ergonomic":
     check:

--- a/tests/test_protobuf2_semantics.proto
+++ b/tests/test_protobuf2_semantics.proto
@@ -1,8 +1,31 @@
 syntax = "proto2";
 
+message Required {
+  optional int32 a = 1;
+  required int32 b = 2;
+}
+
+message FullOfDefaults {
+  optional string a = 3;
+  optional Required b = 4;
+}
+
+message SeqContainer {
+  repeated bool data = 5;
+}
+
+message SeqString {
+  repeated string data = 6;
+}
+
+message FloatOption {
+  optional float x = 1;
+  optional double y = 2;
+}
+
 message FixedOption {
-  optional fixed32 a = 1;
-  optional fixed64 b = 2;
-  optional sfixed32 c = 3;
-  optional sfixed64 d = 4;
+  optional sfixed32 a = 1;
+  optional sfixed64 b = 2;
+  optional fixed32 c = 3;
+  optional fixed64 d = 4;
 }

--- a/tests/test_protobuf2_semantics.proto
+++ b/tests/test_protobuf2_semantics.proto
@@ -1,0 +1,8 @@
+syntax = "proto2";
+
+message FixedOption {
+  optional fixed32 a = 1;
+  optional fixed64 b = 2;
+  optional sfixed32 c = 3;
+  optional sfixed64 d = 4;
+}


### PR DESCRIPTION
Changes:

- do not set `PBOption` if wire type is unexpected
- add regression tests + expected encoding to tests

Regression caused by #74