### PR TITLE
Support custom `seq[T]` serializer for extensions

### DIFF
--- a/protobuf_serialization.nim
+++ b/protobuf_serialization.nim
@@ -3,8 +3,8 @@ import sets
 import serialization
 export serialization
 
-import protobuf_serialization/[internal, types, reader, sizer, writer, format]
-export types, reader, sizer, writer, format
+import protobuf_serialization/[internal, types, reader, sizer, writer, format, extension]
+export types, reader, sizer, writer, format, extension
 
 Protobuf.setReader ProtobufReader
 Protobuf.setWriter ProtobufWriter, PreferredOutput = seq[byte]

--- a/protobuf_serialization/extension.nim
+++ b/protobuf_serialization/extension.nim
@@ -14,15 +14,25 @@ import ./[types, format]
 export types, format
 
 template extensionDefaults*(
-    Format: type Protobuf, ExtType: type, defaultSeq = true, packed = false
+    Format: type Protobuf,
+    ExtType: type,
+    defaultWriteSeq = false,
+    defaultReadSeq = false,
+    defaultSeq = false,
+    packed = false
 ): untyped =
+  ## Generate default procedures for the extension.
+  ## - ``defaultSeq`` generates default ``seq[ExtType]``
+  ##   writer and reader.
+  ## - ``packed`` enables packed procedures overload support.
+
   func supportsPacked*(_: type ExtType, ProtoType: type ProtobufExt): bool =
     false
 
   func supportsPacked*(_: type seq[ExtType], ProtoType: type ProtobufExt): bool =
     packed
 
-  when defaultSeq:
+  when defaultWriteSeq or defaultSeq:
     func computeFieldSize*(
         field: int, 
         value: seq[ExtType],
@@ -44,6 +54,7 @@ template extensionDefaults*(
       for i in 0 ..< value.len:
         stream.writeField(field, value[i], ProtoType, false)
 
+  when defaultReadSeq or defaultSeq:
     proc readFieldInto*(
       stream: InputStream,
       value: var seq[ExtType],

--- a/protobuf_serialization/extension.nim
+++ b/protobuf_serialization/extension.nim
@@ -1,0 +1,58 @@
+# nim-protobuf-serialization
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+{.push raises: [], gcsafe.}
+
+import ./[types, format]
+
+export types, format
+
+template extensionDefaults*(
+    Format: type Protobuf, ExtType: type, defaultSeq = true, packed = false
+): untyped =
+  func supportsPacked*(_: type ExtType, ProtoType: type ProtobufExt): bool =
+    false
+
+  func supportsPacked*(_: type seq[ExtType], ProtoType: type ProtobufExt): bool =
+    packed
+
+  when defaultSeq:
+    func computeFieldSize*(
+        field: int, 
+        value: seq[ExtType],
+        ProtoType: type ProtobufExt,
+        skipDefault: static bool
+    ): int =
+      var dataSize = 0
+      for i in 0 ..< value.len:
+        dataSize += computeFieldSize(field, value[i], ProtoType, false)
+      dataSize
+
+    proc writeField*(
+        stream: OutputStream,
+        field: int,
+        value: seq[ExtType],
+        ProtoType: type ProtobufExt,
+        skipDefault: static bool = false
+    ) {.raises: [IOError].} =
+      for i in 0 ..< value.len:
+        stream.writeField(field, value[i], ProtoType, false)
+
+    proc readFieldInto*(
+      stream: InputStream,
+      value: var seq[ExtType],
+      header: FieldHeader,
+      ProtoType: type ProtobufExt
+    ): bool {.raises: [SerializationError, IOError].} =
+      var val = default(typeof(value[0]))
+      if stream.readFieldInto(val, header, ProtoType):
+        value.add move(val)
+        true
+      else:
+        false

--- a/protobuf_serialization/pkg/results.nim
+++ b/protobuf_serialization/pkg/results.nim
@@ -11,15 +11,15 @@
 
 import
   pkg/results,
-  ../[reader, writer, sizer, internal, format]
+  ../[reader, writer, sizer, internal, format, extension]
 
 export results
+
+Protobuf.extensionDefaults(Opt, defaultSeq = false, packed = false)
 
 template flatType*[U](T: type Protobuf, value: Opt[U]): type = U
 
 func isExtension*(T: type Protobuf, FieldType: type Opt): bool = true
-
-func supportsPacked*(T: type Opt, ProtoType: type ProtobufExt): bool = false
 
 func validateOptType(T: type Opt, ProtoType: type ProtobufExt) =
   when ProtoType.RootType.isProto3():

--- a/protobuf_serialization/reader.nim
+++ b/protobuf_serialization/reader.nim
@@ -15,7 +15,7 @@ export inputs, serialization, codec, types
 
 proc readValueInternal[T: object](stream: InputStream, value: var T, silent: bool = false) {.raises: [SerializationError, IOError].}
 
-proc readFieldInto*[T: not seq and not PBOption](
+proc readFieldInto*[T: not PBOption](
   stream: InputStream,
   value: var T,
   header: FieldHeader,
@@ -81,7 +81,7 @@ proc readFieldInto*[T: not byte](
   stream: InputStream,
   value: var seq[T],
   header: FieldHeader,
-  ProtoType: type # SomeProto
+  ProtoType: type SomeProto
 ): bool {.raises: [SerializationError, IOError].} =
   var val = default(T)
   if stream.readFieldInto(val, header, ProtoType):

--- a/protobuf_serialization/reader.nim
+++ b/protobuf_serialization/reader.nim
@@ -15,7 +15,7 @@ export inputs, serialization, codec, types
 
 proc readValueInternal[T: object](stream: InputStream, value: var T, silent: bool = false) {.raises: [SerializationError, IOError].}
 
-proc readFieldInto*[T: not PBOption](
+proc readFieldInto*[T: not seq and not PBOption](
   stream: InputStream,
   value: var T,
   header: FieldHeader,
@@ -30,6 +30,19 @@ proc readFieldPackedInto*[T](
   ProtoType: type ProtobufExt
 ): bool {.raises: [SerializationError, IOError].} =
   unsupportedProtoType ProtoType.FieldType, ProtoType.RootType, ProtoType.fieldName
+
+proc readFieldInto*[T: not PBOption](
+  stream: InputStream,
+  value: var seq[T],
+  header: FieldHeader,
+  ProtoType: type ProtobufExt
+): bool {.raises: [SerializationError, IOError], deprecated: "use extensionDefaults".} =
+  var val = default(typeof(value[0]))
+  if stream.readFieldInto(val, header, ProtoType):
+    value.add move(val)
+    true
+  else:
+    false
 
 proc readFieldInto*[T: object and not PBOption](
   stream: InputStream,

--- a/protobuf_serialization/sizer.nim
+++ b/protobuf_serialization/sizer.nim
@@ -8,7 +8,7 @@ import
 
 func computeObjectSize*[T: object](value: T): int
 
-func computeFieldSize*[T: not openArray and not PBOption](
+func computeFieldSize*[T: not PBOption](
     field: int, value: T, ProtoType: type ProtobufExt,
     _: static bool) =
   unsupportedProtoType ProtoType.FieldType, ProtoType.RootType, ProtoType.fieldName
@@ -61,7 +61,7 @@ when defined(ConformanceTest):
 func computeFieldSize*[T: not byte](
     field: int, 
     value: openArray[T],
-    ProtoType: type, # SomeProto,
+    ProtoType: type SomeProto,
     skipDefault: static bool
 ): int =
   var dataSize = 0

--- a/protobuf_serialization/sizer.nim
+++ b/protobuf_serialization/sizer.nim
@@ -8,7 +8,7 @@ import
 
 func computeObjectSize*[T: object](value: T): int
 
-func computeFieldSize*[T: not PBOption](
+func computeFieldSize*[T: not seq and not PBOption](
     field: int, value: T, ProtoType: type ProtobufExt,
     _: static bool) =
   unsupportedProtoType ProtoType.FieldType, ProtoType.RootType, ProtoType.fieldName
@@ -16,6 +16,17 @@ func computeFieldSize*[T: not PBOption](
 func computeFieldSizePacked*(
     field: int, values: openArray, ProtoType: type ProtobufExt): int =
   unsupportedProtoType ProtoType.FieldType, ProtoType.RootType, ProtoType.fieldName
+
+func computeFieldSize*[T](
+    field: int, 
+    value: seq[T],
+    ProtoType: type ProtobufExt,
+    skipDefault: static bool
+): int {.deprecated: "use extensionDefaults".} =
+  var dataSize = 0
+  for i in 0 ..< value.len:
+    dataSize += computeFieldSize(field, value[i], ProtoType, false)
+  dataSize
 
 func computeFieldSize*[T: object and not PBOption](
     field: int, value: T, ProtoType: type pbytes,

--- a/protobuf_serialization/std/enums.nim
+++ b/protobuf_serialization/std/enums.nim
@@ -11,7 +11,7 @@
 
 import
   std/[macros, typetraits],
-  ../[reader, writer, sizer, internal]
+  ../[reader, writer, sizer, internal, extension]
 
 from stew/objects import enumRangeInt64
 
@@ -44,8 +44,7 @@ func checkedEnumAssign[E: enum, I: SomeInteger](res: var E, value: I): bool =
     res = cast[E](value)
     true
 
-func supportsPacked*(T: type enum, ProtoType: type ProtobufExt): bool = false
-func supportsPacked*(T: type seq[enum], ProtoType: type ProtobufExt): bool = true
+Protobuf.extensionDefaults(enum, defaultSeq = true, packed = true)
 
 func validateEnumType(T: type enum, ProtoType: type ProtobufExt) =
   bind contains

--- a/protobuf_serialization/writer.nim
+++ b/protobuf_serialization/writer.nim
@@ -14,7 +14,7 @@ export outputs, serialization, codec, types
 
 proc writeObject[T: object](stream: OutputStream, value: T) {.raises: [IOError].}
 
-proc writeField*[T: not PBOption](
+proc writeField*[T: not seq and not PBOption](
     stream: OutputStream, field: int, value: T,
     ProtoType: type ProtobufExt, _: static bool = false) {.raises: [IOError].} =
   unsupportedProtoType ProtoType.FieldType, ProtoType.RootType, ProtoType.fieldName
@@ -22,6 +22,16 @@ proc writeField*[T: not PBOption](
 proc writeFieldPacked*[T: not byte](
     output: OutputStream, field: int, values: openArray[T], ProtoType: type ProtobufExt) {.raises: [IOError].} =
   unsupportedProtoType ProtoType.FieldType, ProtoType.RootType, ProtoType.fieldName
+
+proc writeField*[T](
+    stream: OutputStream,
+    field: int,
+    value: seq[T],
+    ProtoType: type ProtobufExt,
+    skipDefault: static bool = false
+) {.raises: [IOError], deprecated: "use extensionDefaults".} =
+  for i in 0 ..< value.len:
+    stream.writeField(field, value[i], ProtoType, false)
 
 proc writeField*[T: object and not PBOption](
     stream: OutputStream, field: int, value: T, ProtoType: type pbytes,

--- a/protobuf_serialization/writer.nim
+++ b/protobuf_serialization/writer.nim
@@ -14,7 +14,7 @@ export outputs, serialization, codec, types
 
 proc writeObject[T: object](stream: OutputStream, value: T) {.raises: [IOError].}
 
-proc writeField*[T: not openArray and not PBOption](
+proc writeField*[T: not PBOption](
     stream: OutputStream, field: int, value: T,
     ProtoType: type ProtobufExt, _: static bool = false) {.raises: [IOError].} =
   unsupportedProtoType ProtoType.FieldType, ProtoType.RootType, ProtoType.fieldName
@@ -51,7 +51,7 @@ proc writeField*[T: not byte](
     stream: OutputStream,
     field: int,
     value: openArray[T],
-    ProtoType: type, # SomeProto,
+    ProtoType: type SomeProto,
     skipDefault: static bool = false
 ) {.raises: [IOError].} =
   for i in 0 ..< value.len:

--- a/tests/fail/test_extension_defaults.nim
+++ b/tests/fail/test_extension_defaults.nim
@@ -40,4 +40,4 @@ discard Protobuf.encode(Proto2Int32Ext())
 discard Protobuf.decode(default(seq[byte]), Proto2Int32Ext)
 
 # TODO: remove once read/write/sizer for seq[T], type[ProtobufExt] are removed
-quit(1)
+{.error: "remove me".}

--- a/tests/fail/test_extension_defaults.nim
+++ b/tests/fail/test_extension_defaults.nim
@@ -1,0 +1,39 @@
+import ../../protobuf_serialization
+
+type
+  Int32Ext = object
+    x: int32
+
+  Proto2Int32Ext {.proto3.} = object
+    a {.fieldNumber: 1, ext.}: seq[Int32Ext]
+
+Protobuf.extensionDefaults(Int32Ext, defaultSeq = false, packed = false)
+
+# Missing seq[Int32Ext] serializer
+
+func computeFieldSize(
+    field: int,
+    value: Int32Ext,
+    ProtoType: type ProtobufExt,
+    skipDefault: static bool
+): int =
+  computeFieldSize(field, value.x, pint32, skipDefault)
+
+proc writeField(
+    stream: OutputStream,
+    field: int,
+    value: Int32Ext,
+    ProtoType: type ProtobufExt,
+    skipDefault: static bool = false
+) {.raises: [IOError].} =
+  writeField(stream, field, value.x, pint32, skipDefault)
+
+proc readFieldInto(
+    stream: InputStream,
+    value: var Int32Ext,
+    header: FieldHeader,
+    ProtoType: type ProtobufExt
+): bool {.raises: [SerializationError, IOError].} =
+  readFieldInto(stream, value.x, header, pint32)
+
+discard Protobuf.encode(Proto2Int32Ext())

--- a/tests/fail/test_extension_defaults.nim
+++ b/tests/fail/test_extension_defaults.nim
@@ -37,3 +37,7 @@ proc readFieldInto(
   readFieldInto(stream, value.x, header, pint32)
 
 discard Protobuf.encode(Proto2Int32Ext())
+discard Protobuf.decode(default(seq[byte]), Proto2Int32Ext)
+
+# TODO: remove once read/write/sizer for seq[T], type[ProtobufExt] are removed
+quit(1)

--- a/tests/test_extension.nim
+++ b/tests/test_extension.nim
@@ -35,8 +35,7 @@ type
   Proto3Int32ExtSeq {.proto3.} = object
     a {.fieldNumber: 1, ext.}: seq[Int32Ext]
 
-func supportsPacked(T: type Int32Ext, ProtoType: type ProtobufExt): bool = false
-func supportsPacked(T: type seq[Int32Ext], ProtoType: type ProtobufExt): bool = false
+Protobuf.extensionDefaults(Int32Ext, defaultSeq = true, packed = false)
 
 func computeFieldSize(
     field: int,

--- a/tests/test_extension.nim
+++ b/tests/test_extension.nim
@@ -94,3 +94,75 @@ suite "Test Int32Ext":
     roundtrip(Proto3Int32ExtSeq(a: @[Int32Ext(x: 0'i32)]), "0800")
     roundtrip(default(Proto3Int32ExtSeq), "")
     roundtrip(Proto3Int32ExtSeq(a: @[Int32Ext(x: 1'i32), Int32Ext(x: 0'i32)]), "08010800")
+
+type
+  Int32Ext2 = object
+    x: int32
+
+  Proto3Int32Ext2 {.proto3.} = object
+    a {.fieldNumber: 1, ext.}: seq[Int32Ext2]
+
+Protobuf.extensionDefaults(Int32Ext2, defaultSeq = false, packed = false)
+
+func computeFieldSize(
+    field: int,
+    value: Int32Ext2,
+    ProtoType: type ProtobufExt,
+    skipDefault: static bool
+): int =
+  computeFieldSize(field, value.x, pint32, skipDefault)
+
+proc writeField(
+    stream: OutputStream,
+    field: int,
+    value: Int32Ext2,
+    ProtoType: type ProtobufExt,
+    skipDefault: static bool = false
+) {.raises: [IOError].} =
+  writeField(stream, field, value.x, pint32, skipDefault)
+
+proc readFieldInto(
+    stream: InputStream,
+    value: var Int32Ext2,
+    header: FieldHeader,
+    ProtoType: type ProtobufExt
+): bool {.raises: [SerializationError, IOError].} =
+  readFieldInto(stream, value.x, header, pint32)
+
+func computeFieldSize(
+    field: int, 
+    value: seq[Int32Ext2],
+    ProtoType: type ProtobufExt,
+    skipDefault: static bool
+): int =
+  var dataSize = 0
+  for i in 0 ..< value.len:
+    dataSize += computeFieldSize(field, value[i], ProtoType, false)
+  dataSize
+
+proc writeField(
+    stream: OutputStream,
+    field: int,
+    value: seq[Int32Ext2],
+    ProtoType: type ProtobufExt,
+    skipDefault: static bool = false
+) {.raises: [IOError].} =
+  for i in 0 ..< value.len:
+    stream.writeField(field, value[i], ProtoType, false)
+
+proc readFieldInto(
+  stream: InputStream,
+  value: var seq[Int32Ext2],
+  header: FieldHeader,
+  ProtoType: type ProtobufExt
+): bool {.raises: [SerializationError, IOError].} =
+  var val = default(typeof(value[0]))
+  if stream.readFieldInto(val, header, ProtoType):
+    value.add move(val)
+    true
+  else:
+    false
+
+suite "Test seq[T] serializer":
+  test "custom seq[Int32Ext2] serializer":
+    roundtrip(Proto3Int32Ext2(a: @[Int32Ext2(x: 1'i32)]), "0801")

--- a/tests/test_extension.nim
+++ b/tests/test_extension.nim
@@ -129,39 +129,41 @@ proc readFieldInto(
 ): bool {.raises: [SerializationError, IOError].} =
   readFieldInto(stream, value.x, header, pint32)
 
-func computeFieldSize(
-    field: int, 
-    value: seq[Int32Ext2],
-    ProtoType: type ProtobufExt,
-    skipDefault: static bool
-): int =
-  var dataSize = 0
-  for i in 0 ..< value.len:
-    dataSize += computeFieldSize(field, value[i], ProtoType, false)
-  dataSize
+# TODO: when true: once read/write/sizer for seq[T], type[ProtobufExt] are removed
+when false:
+  func computeFieldSize(
+      field: int, 
+      value: seq[Int32Ext2],
+      ProtoType: type ProtobufExt,
+      skipDefault: static bool
+  ): int =
+    var dataSize = 0
+    for i in 0 ..< value.len:
+      dataSize += computeFieldSize(field, value[i], ProtoType, false)
+    dataSize
 
-proc writeField(
-    stream: OutputStream,
-    field: int,
-    value: seq[Int32Ext2],
-    ProtoType: type ProtobufExt,
-    skipDefault: static bool = false
-) {.raises: [IOError].} =
-  for i in 0 ..< value.len:
-    stream.writeField(field, value[i], ProtoType, false)
+  proc writeField(
+      stream: OutputStream,
+      field: int,
+      value: seq[Int32Ext2],
+      ProtoType: type ProtobufExt,
+      skipDefault: static bool = false
+  ) {.raises: [IOError].} =
+    for i in 0 ..< value.len:
+      stream.writeField(field, value[i], ProtoType, false)
 
-proc readFieldInto(
-  stream: InputStream,
-  value: var seq[Int32Ext2],
-  header: FieldHeader,
-  ProtoType: type ProtobufExt
-): bool {.raises: [SerializationError, IOError].} =
-  var val = default(typeof(value[0]))
-  if stream.readFieldInto(val, header, ProtoType):
-    value.add move(val)
-    true
-  else:
-    false
+  proc readFieldInto(
+    stream: InputStream,
+    value: var seq[Int32Ext2],
+    header: FieldHeader,
+    ProtoType: type ProtobufExt
+  ): bool {.raises: [SerializationError, IOError].} =
+    var val = default(typeof(value[0]))
+    if stream.readFieldInto(val, header, ProtoType):
+      value.add move(val)
+      true
+    else:
+      false
 
 suite "Test seq[T] serializer":
   test "custom seq[Int32Ext2] serializer":

--- a/tests/test_objects.nim
+++ b/tests/test_objects.nim
@@ -68,12 +68,12 @@ suite "Test Object Encoding/Decoding":
     writer.writeField(3, obj.f, pbytes)
     writer.writeField(4, pstring(obj.g))
 
-    let result = Protobuf.decode(writer.getOutput(), type(Wrapped))
-    check result.d == obj.d
-    check result.f == obj.f
-    check result.g == obj.g
-    check result.e == 0
-    check result.h == false
+    let ret = Protobuf.decode(writer.getOutput(), type(Wrapped))
+    check ret.d == obj.d
+    check ret.f == obj.f
+    check ret.g == obj.g
+    check ret.e == 0
+    check ret.h == false
 
   test "Can encode/decode out of order object":
     let


### PR DESCRIPTION
Change:

- Add `extensionDefaults(type Protobuf, type, defaultSeq = true, packed = false)` to define default `seq[T]` serializers for the `T` type extension.
- Failing to either call `extensionDefaults` or define size/write/read functions for seq[T] type extensions will emit a deprecation warning. In future versions the deprecated procs can be removed so a compile error is thrown instead.

Backward compatible change.