### PR TITLE
Fix `PBOption` for `std/enum` invalid values

### DIFF
--- a/protobuf_serialization/reader.nim
+++ b/protobuf_serialization/reader.nim
@@ -85,15 +85,7 @@ proc readFieldInto*[T: not object and (seq[byte] or not seq)](
   ProtoType: type SomeProto
 ): bool {.raises: [SerializationError, IOError].} =
   if header.kind() == wireKind(ProtoType):
-    when ProtoType is SomeVarint:
-      assign(value, T(stream.readValue(ProtoType)))
-    elif ProtoType is SomeFixed64:
-      assign(value, T(stream.readValue(ProtoType)))
-    elif ProtoType is SomeLengthDelim:
-      assign(value, T(stream.readValue(ProtoType)))
-    else:
-      static: doAssert ProtoType is SomeFixed32
-      assign(value, T(stream.readValue(ProtoType)))
+    assign(value, T(stream.readValue(ProtoType)))
     true
   else:
     false
@@ -117,10 +109,11 @@ proc readFieldInto*(
   header: FieldHeader,
   ProtoType: type
 ): bool {.raises: [SerializationError, IOError].} =
-  if stream.readFieldInto(value.mget(), header, ProtoType):
+  var val: typeof(value.get())
+  if stream.readFieldInto(val, header, ProtoType):
+    init(value, move(val))
     true
   else:
-    reset(value)
     false
 
 proc readFieldPackedInto*[T: not byte](

--- a/protobuf_serialization/types.nim
+++ b/protobuf_serialization/types.nim
@@ -120,9 +120,9 @@ template pbSome*(value: untyped): untyped =
 template pbNone*(value: untyped): untyped =
   PBOption[value]()
 
-func init*(opt: var PBOption, val: auto) =
+func init*(opt: var PBOption, val: sink auto) =
   opt.some = true
-  opt.value = val
+  opt.value = move(val)
 
 converter toValue*(opt: PBOption): auto {.inline.} =
   opt.get()

--- a/protobuf_serialization/types.nim
+++ b/protobuf_serialization/types.nim
@@ -120,9 +120,9 @@ template pbSome*(value: untyped): untyped =
 template pbNone*(value: untyped): untyped =
   PBOption[value]()
 
-func init*(opt: var PBOption, val: sink auto) =
+func init*(opt: var PBOption, val: auto) =
   opt.some = true
-  opt.value = move(val)
+  opt.value = val
 
 converter toValue*(opt: PBOption): auto {.inline.} =
   opt.get()

--- a/tests/test_all.nim
+++ b/tests/test_all.nim
@@ -19,6 +19,7 @@ import
   test_groups,
   test_objects,
   test_pkg_results,
+  test_pkg_results_enums,
   test_empty,
   test_repeated,
   test_std_enums,

--- a/tests/test_pkg_results_enums.nim
+++ b/tests/test_pkg_results_enums.nim
@@ -33,6 +33,12 @@ suite "Test Opt[enum] Encoding/Decoding":
     roundtrip(ObjClassicOptP2(x: Opt.some(B1)), "0801")
     roundtrip(ObjClassicOptP2(x: Opt.some(C1)), "0802")
 
+  test "proto2 optional multiple enums":
+    # echo "08020801" | xxd -r -p | protoc --decode=ObjClassicOptP2 test_std_enums_2.proto
+    # x: B1
+    let encoded = "08020801".hexToSeqByte
+    check Protobuf.decode(encoded, ObjClassicOptP2) == ObjClassicOptP2(x: Opt.some(B1))
+
   test "proto2 optional enum invalid":
     # echo "0803" | xxd -r -p | protoc --decode=ObjClassicOptP2 test_std_enums_2.proto
     # 1: 3

--- a/tests/test_pkg_results_enums.nim
+++ b/tests/test_pkg_results_enums.nim
@@ -1,0 +1,51 @@
+# nim-protobuf-serialization
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+import
+  unittest2,
+  stew/byteutils,
+  ./utils,
+  ../protobuf_serialization,
+  ../protobuf_serialization/std/enums,
+  ../protobuf_serialization/pkg/results
+
+type
+  Classic = enum
+    A1
+    B1
+    C1
+
+  ObjClassicOptP2 {.proto2.} = object
+    x {.fieldNumber: 1, ext.}: Opt[Classic]
+
+suite "Test Opt[enum] Encoding/Decoding":
+  test "proto2 optional enum":
+    # pbNone: field absent, encodes to empty
+    roundtrip(ObjClassicOptP2(x: Opt.none(Classic)), "")
+    # pbSome: field present, encoded even when value matches the default int (0)
+    roundtrip(ObjClassicOptP2(x: Opt.some(A1)), "0800")
+    roundtrip(ObjClassicOptP2(x: Opt.some(B1)), "0801")
+    roundtrip(ObjClassicOptP2(x: Opt.some(C1)), "0802")
+
+  test "proto2 optional enum invalid":
+    # echo "0803" | xxd -r -p | protoc --decode=ObjClassicOptP2 test_std_enums_2.proto
+    # 1: 3
+    let encoded = "0803".hexToSeqByte
+    check Protobuf.decode(encoded, ObjClassicOptP2) == ObjClassicOptP2(x: Opt.none(Classic))
+
+  test "proto2 optional enum + invalid":
+    # echo "08010803" | xxd -r -p | protoc --decode=ObjClassicOptP2 test_std_enums_2.proto
+    # x: B1
+    # 1: 3
+    block:
+      let encoded = "08010803".hexToSeqByte
+      check Protobuf.decode(encoded, ObjClassicOptP2) == ObjClassicOptP2(x: Opt.some(B1))
+    block:
+      let encoded = "08030801".hexToSeqByte
+      check Protobuf.decode(encoded, ObjClassicOptP2) == ObjClassicOptP2(x: Opt.some(B1))

--- a/tests/test_std_enums.nim
+++ b/tests/test_std_enums.nim
@@ -123,6 +123,12 @@ suite "Test Enum Encoding/Decoding":
     roundtrip(ObjClassicOptP2(x: pbSome(B1)), "0801")
     roundtrip(ObjClassicOptP2(x: pbSome(C1)), "0802")
 
+  test "proto2 optional multiple enums":
+    # echo "08020801" | xxd -r -p | protoc --decode=ObjClassicOptP2 test_std_enums_2.proto
+    # x: B1
+    let encoded = "08020801".hexToSeqByte
+    check Protobuf.decode(encoded, ObjClassicOptP2) == ObjClassicOptP2(x: pbSome(B1))
+
   test "proto2 optional enum invalid":
     # echo "0803" | xxd -r -p | protoc --decode=ObjClassicOptP2 test_std_enums_2.proto
     # 1: 3

--- a/tests/test_std_enums.nim
+++ b/tests/test_std_enums.nim
@@ -129,6 +129,17 @@ suite "Test Enum Encoding/Decoding":
     let encoded = "0803".hexToSeqByte
     check Protobuf.decode(encoded, ObjClassicOptP2) == ObjClassicOptP2(x: pbNone(default(Classic)))
 
+  test "proto2 optional enum + invalid":
+    # echo "08010803" | xxd -r -p | protoc --decode=ObjClassicOptP2 test_std_enums_2.proto
+    # x: B1
+    # 1: 3
+    block:
+      let encoded = "08010803".hexToSeqByte
+      check Protobuf.decode(encoded, ObjClassicOptP2) == ObjClassicOptP2(x: pbSome(B1))
+    block:
+      let encoded = "08030801".hexToSeqByte
+      check Protobuf.decode(encoded, ObjClassicOptP2) == ObjClassicOptP2(x: pbSome(B1))
+
   test "proto2 repeated enum":
     # echo "080008010802" | xxd -r -p | protoc --decode=ObjRepeatedP2 test_std_enums_2.proto
     # echo 'x: 0 x: 1 x: 2' | protoc --encode=ObjRepeatedP2 test_std_enums_2.proto | hexdump -ve '1/1 "%.2x"'


### PR DESCRIPTION
Changes:

- `PBOption` enum valid read value is no longer replaced by `0` on later invalid values
- `assign(value, T(stream.readValue(ProtoType)))` clean up

`pkg/results` is not affected.