### PR TITLE
Pass `--enforce_recommended` to conformance tests

### DIFF
--- a/protobuf_serialization.nimble
+++ b/protobuf_serialization.nimble
@@ -68,4 +68,4 @@ task conformance_test, "Run conformance tests":
   exec "cp " & conformance / "conformance_test_runner" & " " & test
   withDir test:
     exec "nim c -d:ConformanceTest conformance_nim.nim"
-    exec "./conformance_test_runner --failure_list failure_list.txt conformance_nim"
+    exec "./conformance_test_runner --enforce_recommended --failure_list failure_list.txt conformance_nim"

--- a/tests/conformance/failure_list.txt
+++ b/tests/conformance/failure_list.txt
@@ -1,3 +1,12 @@
+Recommended.Proto2.ProtobufInput.OneofZeroMessage.ProtobufOutput # Output was not equivalent to reference message: deleted: oneof_nested_message: { a: 0 }
+Recommended.Proto2.ProtobufInput.OneofZeroMessageSetTwice.ProtobufOutput # Output was not equivalent to reference message: deleted: oneof_nested_message: { a: 1 }
+Recommended.Proto2.ProtobufInput.ValidDataOneofBinary.MESSAGE.DefaultValue.ProtobufOutput # Output was not equivalent to reference message: Expect: \202\007\000, but got: 
+Recommended.Proto2.ProtobufInput.ValidDataOneofBinary.MESSAGE.Merge.ProtobufOutput # Output was not equivalent to reference message: Expect: \202\007\014\022\012\010\001\020\001\310\005\001\310\005\001, but got: 
+Recommended.Proto2.ProtobufInput.ValidDataOneofBinary.MESSAGE.MultipleValuesForDifferentField.ProtobufOutput # Output was not equivalent to reference message: Expect: \202\007\003\010\322\011, but got: \370\006\000
+Recommended.Proto2.ProtobufInput.ValidDataOneofBinary.MESSAGE.MultipleValuesForSameField.ProtobufOutput # Output was not equivalent to reference message: Expect: \202\007\003\010\322\011, but got: 
+Recommended.Proto2.ProtobufInput.ValidDataOneofBinary.MESSAGE.NonDefaultValue.ProtobufOutput # Output was not equivalent to reference message: Expect: \202\007\003\010\322\011, but got: 
+Recommended.Proto2.ProtobufInput.ValidDataScalarBinary.MESSAGE[0].ProtobufOutput # Output was not equivalent to reference message: Expect: \222\001\000, but got: 
+Recommended.Proto2.ProtobufInput.ValidDataScalarBinary.MESSAGE[1].ProtobufOutput # Output was not equivalent to reference message: Expect: \222\001\003\010\322\011, but got: 
 Required.Proto2.ProtobufInput.PrematureEofInSubmessageValue.MESSAGE # Should have failed to parse, but didn't.
 Required.Proto2.ProtobufInput.RepeatedScalarMessageMerge.ProtobufOutput # Output was not equivalent to reference message: deleted: optional_nested_message: { corecursive { optional_int32: 4321 optional_
 Required.Proto2.ProtobufInput.UnknownOrdering.ProtobufOutput # Unknown field mismatch

--- a/tests/test_protobuf2_semantics.nim
+++ b/tests/test_protobuf2_semantics.nim
@@ -21,6 +21,7 @@ type
   FullOfDefaults {.proto2.} = object
     a {.fieldNumber: 3.}: PBOption["abc"]
     b {.fieldNumber: 4.}: PBOption[default(Required)]
+    c {.fieldNumber: 5, pint.}: PBOption[0'i32]
 
   SeqContainer {.proto2.} = object
     data {.fieldNumber: 5.}: seq[bool]
@@ -72,6 +73,15 @@ suite "Test Encoding of Protobuf 2 Semantics":
     # echo 'b: { b: 5 }' | protoc --encode=FullOfDefaults test_protobuf2_semantics.proto | hexdump -ve '1/1 "%.2x"'
     # 22021005
     roundtrip(FullOfDefaults(b: pbSome(Required(b: 5))), "22021005")
+    # echo 'a: "abc"' | protoc --encode=FullOfDefaults test_protobuf2_semantics.proto | hexdump -ve '1/1 "%.2x"'
+    # 1a03616263
+    roundtrip(FullOfDefaults(a: PBOption["abc"].pbSome("abc")), "1a03616263")
+    # echo 'a: "def"' | protoc --encode=FullOfDefaults test_protobuf2_semantics.proto | hexdump -ve '1/1 "%.2x"'
+    # 1a03646566
+    roundtrip(FullOfDefaults(a: PBOption["abc"].pbSome("def")), "1a03646566")
+    # echo 'c: 0' | protoc --encode=FullOfDefaults test_protobuf2_semantics.proto | hexdump -ve '1/1 "%.2x"'
+    roundtrip(FullOfDefaults(c: pbSome(0'i32)), "2800")
+    roundtrip(FullOfDefaults(c: pbNone(0'i32)), "")
     check:
       # PBOption is isNone when field is absent; get() returns the type default, not unset
       Protobuf.decode("1000".hexToSeqByte, Required).a.isNone()

--- a/tests/test_protobuf2_semantics.proto
+++ b/tests/test_protobuf2_semantics.proto
@@ -6,8 +6,9 @@ message Required {
 }
 
 message FullOfDefaults {
-  optional string a = 3;
+  optional string a = 3 [default = "abc"];
   optional Required b = 4;
+  optional int32 c = 5;
 }
 
 message SeqContainer {


### PR DESCRIPTION
- Turn warnings into errors to catch regressions.
- Add some PBOption tests