### PR TITLE
Support `results.Opt` extension in `proto3`

### DIFF
--- a/protobuf_serialization/internal.nim
+++ b/protobuf_serialization/internal.nim
@@ -287,8 +287,7 @@ func verifySerializable*[T](ty: typedesc[T]) {.compileTime.} =
           fieldError T, fieldName, "proto2 requires every field to either have the required pragma attached or be a repeated field/PBOption."
         when isProto3 and (
           T.hasCustomPragmaFixed(fieldName, required) or
-          fieldVal is PBOption or
-          isExtension(Protobuf, fieldValTyp)
+          fieldVal is PBOption
         ):
           fieldError T, fieldName, "The required pragma/PBOption type can only be used with proto2."
 

--- a/protobuf_serialization/pkg/results.nim
+++ b/protobuf_serialization/pkg/results.nim
@@ -21,20 +21,15 @@ template flatType*[U](T: type Protobuf, value: Opt[U]): type = U
 
 func isExtension*(T: type Protobuf, FieldType: type Opt): bool = true
 
-func validateOptType(T: type Opt, ProtoType: type ProtobufExt) =
-  when ProtoType.RootType.isProto3():
-    {.fatal: $T & " Opt is only supported in proto2".}
-
 func computeFieldSize*(
     field: int,
     value: Opt,
     ProtoType: type ProtobufExt,
     skipDefault: static bool
 ): int =
-  validateOptType(typeof(value), ProtoType)
   protoType(InnerProtoType, ProtoType.RootType, Protobuf.flatType(value), ProtoType.fieldName)
   if value.isSome():
-    computeFieldSize(field, value.get(), InnerProtoType, skipDefault)
+    computeFieldSize(field, value.get(), InnerProtoType, false)
   else:
     0
 
@@ -45,10 +40,9 @@ proc writeField*(
     ProtoType: type ProtobufExt,
     skipDefault: static bool = false
 ) {.raises: [IOError].} =
-  validateOptType(typeof(value), ProtoType)
   protoType(InnerProtoType, ProtoType.RootType, Protobuf.flatType(value), ProtoType.fieldName)
   if value.isSome():
-    stream.writeField(field, value.get(), InnerProtoType, skipDefault)
+    stream.writeField(field, value.get(), InnerProtoType, false)
 
 proc readFieldInto*(
     stream: InputStream,
@@ -56,7 +50,6 @@ proc readFieldInto*(
     header: FieldHeader,
     ProtoType: type ProtobufExt
 ): bool {.raises: [SerializationError, IOError].} =
-  validateOptType(typeof(value), ProtoType)
   protoType(InnerProtoType, ProtoType.RootType, Protobuf.flatType(value), ProtoType.fieldName)
   var val: typeof(value.get())
   if stream.readFieldInto(val, header, InnerProtoType):

--- a/tests/test_pkg_results.nim
+++ b/tests/test_pkg_results.nim
@@ -23,14 +23,61 @@ type
     a {.fieldNumber: 3.}: Opt[string]
     b {.fieldNumber: 4.}: Opt[FewOptions]
 
+  P3FewOptions {.proto3.} = object
+    a {.fieldNumber: 1, pint.}: Opt[int32]
+    b {.fieldNumber: 2, pint.}: Opt[int32]
+
+  P3FullOfDefaults {.proto3.} = object
+    a {.fieldNumber: 3.}: Opt[string]
+    b {.fieldNumber: 4.}: Opt[P3FewOptions]
+
 suite "Test results Opt[T]":
-  test "sets optional valid field":
+  test "proto2 sets optional valid field":
     # echo 'b: { b: 5 }' | protoc --encode=FullOfDefaults test_protobuf2_semantics.proto | hexdump -ve '1/1 "%.2x"'
     # 22021005
     roundtrip(FullOfDefaults(b: Opt.some(FewOptions(b: Opt.some(5'i32)))), "22021005")
 
-  test "unexpected type does not set Opt":
-    # echo "0801" | xxd -r -p | protoc --decode=FixedOption test_protobuf2_semantics.proto
+  test "proto2 unexpected type does not set Opt":
+    # echo "0801" | xxd -r -p | protoc --decode=FullOfDefaults test_protobuf2_semantics.proto
     # 1: 1
     let encoded = "0801".hexToSeqByte
     check Protobuf.decode(encoded, FullOfDefaults) == FullOfDefaults()
+
+  test "proto2 optional default":
+    # echo 'a: 0' | protoc --encode=FewOptions test_pkg_results_2.proto | hexdump -ve '1/1 "%.2x"'
+    # 0800
+    # echo "0800" | xxd -r -p | protoc --decode=FewOptions test_pkg_results_2.proto
+    # a: 0
+    roundtrip(FewOptions(a: Opt.some(0'i32)), "0800")
+
+  test "proto2 optional set":
+    # echo 'a: 1' | protoc --encode=FewOptions test_pkg_results_2.proto | hexdump -ve '1/1 "%.2x"'
+    # 0801
+    # echo "0801" | xxd -r -p | protoc --decode=FewOptions test_pkg_results_2.proto
+    # a: 1
+    roundtrip(FewOptions(a: Opt.some(1'i32)), "0801")
+
+  test "proto3 sets optional valid field":
+    # echo 'b: { b: 5 }' | protoc --encode=P3FullOfDefaults test_pkg_results_3.proto | hexdump -ve '1/1 "%.2x"'
+    # 22021005
+    roundtrip(P3FullOfDefaults(b: Opt.some(P3FewOptions(b: Opt.some(5'i32)))), "22021005")
+
+  test "proto3 unexpected type does not set Opt":
+    # echo "0801" | xxd -r -p | protoc --decode=P3FullOfDefaults test_pkg_results_3.proto
+    # 1: 1
+    let encoded = "0801".hexToSeqByte
+    check Protobuf.decode(encoded, P3FullOfDefaults) == P3FullOfDefaults()
+
+  test "proto3 optional default":
+    # echo 'a: 0' | protoc --encode=P3FewOptions test_pkg_results_3.proto | hexdump -ve '1/1 "%.2x"'
+    # 0800
+    # echo "0800" | xxd -r -p | protoc --decode=P3FewOptions test_pkg_results_3.proto
+    # a: 0
+    roundtrip(P3FewOptions(a: Opt.some(0'i32)), "0800")
+
+  test "proto3 optional set":
+    # echo 'a: 1' | protoc --encode=P3FewOptions test_pkg_results_3.proto | hexdump -ve '1/1 "%.2x"'
+    # 0801
+    # echo "0801" | xxd -r -p | protoc --decode=P3FewOptions test_pkg_results_3.proto
+    # a: 1
+    roundtrip(P3FewOptions(a: Opt.some(1'i32)), "0801")

--- a/tests/test_pkg_results_2.proto
+++ b/tests/test_pkg_results_2.proto
@@ -1,0 +1,11 @@
+syntax = "proto2";
+
+message FewOptions {
+  optional int32 a = 1;
+  optional int32 b = 2;
+}
+
+message FullOfDefaults {
+  optional string a = 3;
+  optional FewOptions b = 4;
+}

--- a/tests/test_pkg_results_3.proto
+++ b/tests/test_pkg_results_3.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+message P3FewOptions {
+  optional int32 a = 1;
+  optional int32 b = 2;
+}
+
+message P3FullOfDefaults {
+  optional string a = 3;
+  optional P3FewOptions b = 4;
+}

--- a/tests/test_pkg_results_enums.nim
+++ b/tests/test_pkg_results_enums.nim
@@ -24,6 +24,9 @@ type
   ObjClassicOptP2 {.proto2.} = object
     x {.fieldNumber: 1, ext.}: Opt[Classic]
 
+  ObjClassicOptP3 {.proto3.} = object
+    x {.fieldNumber: 1, ext.}: Opt[Classic]
+
 suite "Test Opt[enum] Encoding/Decoding":
   test "proto2 optional enum":
     # pbNone: field absent, encodes to empty
@@ -55,3 +58,28 @@ suite "Test Opt[enum] Encoding/Decoding":
     block:
       let encoded = "08030801".hexToSeqByte
       check Protobuf.decode(encoded, ObjClassicOptP2) == ObjClassicOptP2(x: Opt.some(B1))
+
+  test "proto3 optional enum":
+    # pbNone: field absent, encodes to empty
+    roundtrip(ObjClassicOptP3(x: Opt.none(Classic)), "")
+    # pbSome: field present, encoded even when value matches the default int (0)
+    roundtrip(ObjClassicOptP3(x: Opt.some(A1)), "0800")
+    roundtrip(ObjClassicOptP3(x: Opt.some(B1)), "0801")
+    roundtrip(ObjClassicOptP3(x: Opt.some(C1)), "0802")
+
+  test "proto3 optional multiple enums":
+    let encoded = "08020801".hexToSeqByte
+    check Protobuf.decode(encoded, ObjClassicOptP3) == ObjClassicOptP3(x: Opt.some(B1))
+
+  test "proto3 optional enum invalid":
+    let encoded = "0803".hexToSeqByte
+    check Protobuf.decode(encoded, ObjClassicOptP3) == ObjClassicOptP3(x: Opt.none(Classic))
+
+  test "proto3 optional enum + invalid":
+    block:
+      let encoded = "08010803".hexToSeqByte
+      check Protobuf.decode(encoded, ObjClassicOptP3) == ObjClassicOptP3(x: Opt.some(B1))
+    block:
+      let encoded = "08030801".hexToSeqByte
+      check Protobuf.decode(encoded, ObjClassicOptP3) == ObjClassicOptP3(x: Opt.some(B1))
+


### PR DESCRIPTION
Ref #42

`optional` in proto3 works the same way as in proto2 except it does not allow to set a `[default = xxx]`.