### PR TITLE
Add missing `seq[byte]` proto2 validation

### DIFF
--- a/protobuf_serialization/internal.nim
+++ b/protobuf_serialization/internal.nim
@@ -282,7 +282,8 @@ func verifySerializable*[T](ty: typedesc[T]) {.compileTime.} =
             verifySerializable(fTyp)
       else:
         when isProto2 and not T.isRequired(fieldName) and
-            fieldVal isnot (seq or PBOption) and
+            fieldVal isnot PBOption and
+            (fieldVal isnot seq or fieldVal is seq[byte]) and
             not isExtension(Protobuf, fieldValTyp):
           fieldError T, fieldName, "proto2 requires every field to either have the required pragma attached or be a repeated field/PBOption."
         when isProto3 and (

--- a/tests/fail/test_invalid_proto2_bytes.nim
+++ b/tests/fail/test_invalid_proto2_bytes.nim
@@ -1,0 +1,8 @@
+import ../../protobuf_serialization
+
+type
+  Bytes {.proto2.} = object
+    #a {.fieldNumber: 1, required.}: seq[byte]
+    a {.fieldNumber: 1.}: seq[byte]
+
+discard Protobuf.encode(Bytes())

--- a/tests/fail/test_invalid_proto2_pboption_seq.nim
+++ b/tests/fail/test_invalid_proto2_pboption_seq.nim
@@ -1,0 +1,7 @@
+import ../../protobuf_serialization
+
+type
+  FullOfDefaults {.proto2.} = object
+    a {.fieldNumber: 1.}: PBOption[default(seq[string])]
+
+discard Protobuf.encode(FullOfDefaults())

--- a/tests/test_pkg_results.nim
+++ b/tests/test_pkg_results.nim
@@ -23,6 +23,23 @@ type
     a {.fieldNumber: 3.}: Opt[string]
     b {.fieldNumber: 4.}: Opt[FewOptions]
 
+  P2AllTypesOpt {.proto2.} = object
+    x01 {.fieldNumber: 1.}: Opt[string]
+    x02 {.fieldNumber: 2.}: Opt[seq[byte]]
+    x03 {.fieldNumber: 3, pint.}: Opt[int32]
+    x04 {.fieldNumber: 4, pint.}: Opt[uint32]
+    x05 {.fieldNumber: 5, pint.}: Opt[int64]
+    x06 {.fieldNumber: 6, pint.}: Opt[uint64]
+    x07 {.fieldNumber: 7, sint.}: Opt[int32]
+    x08 {.fieldNumber: 8, sint.}: Opt[int64]
+    x09 {.fieldNumber: 9, fixed.}: Opt[int32]
+    x10 {.fieldNumber: 10, fixed.}: Opt[int64]
+    x11 {.fieldNumber: 11, fixed.}: Opt[uint32]
+    x12 {.fieldNumber: 12, fixed.}: Opt[uint64]
+    x13 {.fieldNumber: 13.}: Opt[float32]
+    x14 {.fieldNumber: 14.}: Opt[float64]
+    x15 {.fieldNumber: 15.}: Opt[FewOptions]
+
   P3FewOptions {.proto3.} = object
     a {.fieldNumber: 1, pint.}: Opt[int32]
     b {.fieldNumber: 2, pint.}: Opt[int32]
@@ -31,7 +48,27 @@ type
     a {.fieldNumber: 3.}: Opt[string]
     b {.fieldNumber: 4.}: Opt[P3FewOptions]
 
+  P3AllTypesOpt {.proto3.} = object
+    x01 {.fieldNumber: 1.}: Opt[string]
+    x02 {.fieldNumber: 2.}: Opt[seq[byte]]
+    x03 {.fieldNumber: 3, pint.}: Opt[int32]
+    x04 {.fieldNumber: 4, pint.}: Opt[uint32]
+    x05 {.fieldNumber: 5, pint.}: Opt[int64]
+    x06 {.fieldNumber: 6, pint.}: Opt[uint64]
+    x07 {.fieldNumber: 7, sint.}: Opt[int32]
+    x08 {.fieldNumber: 8, sint.}: Opt[int64]
+    x09 {.fieldNumber: 9, fixed.}: Opt[int32]
+    x10 {.fieldNumber: 10, fixed.}: Opt[int64]
+    x11 {.fieldNumber: 11, fixed.}: Opt[uint32]
+    x12 {.fieldNumber: 12, fixed.}: Opt[uint64]
+    x13 {.fieldNumber: 13.}: Opt[float32]
+    x14 {.fieldNumber: 14.}: Opt[float64]
+    x15 {.fieldNumber: 15.}: Opt[P3FewOptions]
+
 suite "Test results Opt[T]":
+  test "proto2 all types":
+    roundtrip(P2AllTypesOpt(), "")
+
   test "proto2 sets optional valid field":
     # echo 'b: { b: 5 }' | protoc --encode=FullOfDefaults test_pkg_results_2.proto | hexdump -ve '1/1 "%.2x"'
     # 22021005
@@ -83,6 +120,9 @@ suite "Test results Opt[T]":
     let encoded = "220208012202100122020802".hexToSeqByte
     check Protobuf.decode(encoded, FullOfDefaults) ==
       FullOfDefaults(b: Opt.some(FewOptions(a: Opt.some(2'i32), b: Opt.some(1'i32))))
+
+  test "proto3 all types":
+    roundtrip(P3AllTypesOpt(), "")
 
   test "proto3 sets optional valid field":
     # echo 'b: { b: 5 }' | protoc --encode=P3FullOfDefaults test_pkg_results_3.proto | hexdump -ve '1/1 "%.2x"'

--- a/tests/test_protobuf2_semantics.nim
+++ b/tests/test_protobuf2_semantics.nim
@@ -44,7 +44,27 @@ type
     c {.fieldNumber: 3, fixed.}: PBOption[0'u32]
     d {.fieldNumber: 4, fixed.}: PBOption[0'u64]
 
+  AllTypesOpt {.proto2.} = object
+    x01 {.fieldNumber: 1.}: PBOption[default(string)]
+    x02 {.fieldNumber: 2.}: PBOption[default(seq[byte])]
+    x03 {.fieldNumber: 3, pint.}: PBOption[0'i32]
+    x04 {.fieldNumber: 4, pint.}: PBOption[0'u32]
+    x05 {.fieldNumber: 5, pint.}: PBOption[0'i64]
+    x06 {.fieldNumber: 6, pint.}: PBOption[0'u64]
+    x07 {.fieldNumber: 7, sint.}: PBOption[0'i32]
+    x08 {.fieldNumber: 8, sint.}: PBOption[0'i64]
+    x09 {.fieldNumber: 9, fixed.}: PBOption[0'i32]
+    x10 {.fieldNumber: 10, fixed.}: PBOption[0'i64]
+    x11 {.fieldNumber: 11, fixed.}: PBOption[0'u32]
+    x12 {.fieldNumber: 12, fixed.}: PBOption[0'u64]
+    x13 {.fieldNumber: 13.}: PBOption[0'f32]
+    x14 {.fieldNumber: 14.}: PBOption[0'f64]
+    x15 {.fieldNumber: 15.}: PBOption[default(FewOptions)]
+
 suite "Test Encoding of Protobuf 2 Semantics":
+  test "PBOption all types":
+    roundtrip(AllTypesOpt(), "")
+
   test "PBOption basics":
     var opt: PBOption[true]
     check:


### PR DESCRIPTION
Changes:

- Add missing seq[byte] proto2 validation; do not allow seq[byte] without being optional or required
- Add tests for optional