### PR TITLE
import_proto3: remove oneof namespace

### DIFF
--- a/protobuf_serialization/files/type_generator.nim
+++ b/protobuf_serialization/files/type_generator.nim
@@ -124,7 +124,7 @@ proc protoToTypesInternal*(filepath: string, isProto3 = true): NimNode {.compile
             # Oneof does not allow: map, repeated, optional
             let field = ProtoNode(
               kind: ProtoType.Oneof,
-              oneofName: msg.messageName & field.oneofName.capitalizeAscii(),
+              oneofName: field.oneofName.capitalizeAscii(),
               oneof: field.oneof
             )
             queue.add(field)
@@ -239,7 +239,7 @@ proc protoToTypesInternal*(filepath: string, isProto3 = true): NimNode {.compile
                 ),
                 newNimNode(nnkPragma).add(ident("oneof"))
               ),
-              ident(next.messageName & field.oneofName.capitalizeAscii()),
+              ident(field.oneofName.capitalizeAscii()),
               newEmptyNode()
             ))
           of ProtoType.Field:

--- a/tests/conformance/conformance_nim.nim
+++ b/tests/conformance/conformance_nim.nim
@@ -34,15 +34,15 @@ template processPayload(payload, DecodeType): untyped =
     let x = Protobuf.decode(payload, DecodeType)
     try:
       ConformanceResponse(
-        result: ConformanceResponseResult(
-          kind: ConformanceResponseResultKind.protobuf_payload,
+        result: Result(
+          kind: ResultKind.protobuf_payload,
           protobuf_payload: Protobuf.encode(x)
         )
       )
     except ProtobufError as exc:
       ConformanceResponse(
-        result: ConformanceResponseResult(
-          kind: ConformanceResponseResultKind.serialize_error,
+        result: Result(
+          kind: ResultKind.serialize_error,
           serialize_error: "serialize_error: " & exc.msg
         )
       )
@@ -50,18 +50,18 @@ template processPayload(payload, DecodeType): untyped =
   #  ConformanceResponse(skipped: "skipped: " & exc.msg)
   except ProtobufError as exc:
       ConformanceResponse(
-        result: ConformanceResponseResult(
-          kind: ConformanceResponseResultKind.parse_error,
+        result: Result(
+          kind: ResultKind.parse_error,
           parse_error: "parse_error: " & exc.msg
         )
       )
 
 proc doTest(request: ConformanceRequest): ConformanceResponse =
   if request.requested_output_format != WireFormat.PROTOBUF or
-      request.payload.kind != ConformanceRequestPayloadKind.protobuf_payload:
+      request.payload.kind != PayloadKind.protobuf_payload:
     ConformanceResponse(
-      result: ConformanceResponseResult(
-        kind: ConformanceResponseResultKind.skipped,
+      result: Result(
+        kind: ResultKind.skipped,
         skipped: "skip not protobuf"
       )
     )
@@ -71,8 +71,8 @@ proc doTest(request: ConformanceRequest): ConformanceResponse =
     processPayload(request.payload.protobuf_payload, TestAllTypesProto2)
   else:
     ConformanceResponse(
-      result: ConformanceResponseResult(
-        kind: ConformanceResponseResultKind.skipped,
+      result: Result(
+        kind: ResultKind.skipped,
         skipped: "skip unknown message type: " & request.message_type
       )
     )

--- a/tests/files/test_proto3.nim
+++ b/tests/files/test_proto3.nim
@@ -20,7 +20,7 @@ macro test() =
         TestMessage* {.proto3.} = object
           map_string_bytes* {.fieldNumber: 1.}: seq[Map_string_bytesEntry]
 
-        TestOneOfOneof_fieldKind* {.pure, proto3.} = enum
+        Oneof_fieldKind* {.pure, proto3.} = enum
           notSet = 0
           oneof_uint32 = 1
           oneof_string = 2
@@ -32,32 +32,32 @@ macro test() =
           oneof_enum = 8
           oneof_any = 9
 
-        TestOneOfOneof_field* {.proto3, oneof.} = object
-          case kind*: TestOneOfOneof_fieldKind
-          of TestOneOfOneof_fieldKind.notSet:
+        Oneof_field* {.proto3, oneof.} = object
+          case kind*: Oneof_fieldKind
+          of Oneof_fieldKind.notSet:
             discard
-          of TestOneOfOneof_fieldKind.oneof_uint32:
+          of Oneof_fieldKind.oneof_uint32:
             oneof_uint32* {.fieldNumber: 3, pint.}: uint32
-          of TestOneOfOneof_fieldKind.oneof_string:
+          of Oneof_fieldKind.oneof_string:
             oneof_string* {.fieldNumber: 4.}: string
-          of TestOneOfOneof_fieldKind.oneof_bytes:
+          of Oneof_fieldKind.oneof_bytes:
             oneof_bytes* {.fieldNumber: 5.}: seq[byte]
-          of TestOneOfOneof_fieldKind.oneof_bool:
+          of Oneof_fieldKind.oneof_bool:
             oneof_bool* {.fieldNumber: 6.}: bool
-          of TestOneOfOneof_fieldKind.oneof_uint64:
+          of Oneof_fieldKind.oneof_uint64:
             oneof_uint64* {.fieldNumber: 7, pint.}: uint64
-          of TestOneOfOneof_fieldKind.oneof_float:
+          of Oneof_fieldKind.oneof_float:
             oneof_float* {.fieldNumber: 8.}: float32
-          of TestOneOfOneof_fieldKind.oneof_double:
+          of Oneof_fieldKind.oneof_double:
             oneof_double* {.fieldNumber: 9.}: float64
-          of TestOneOfOneof_fieldKind.oneof_enum:
+          of Oneof_fieldKind.oneof_enum:
             oneof_enum* {.fieldNumber: 10, ext.}: TestEnum
-          of TestOneOfOneof_fieldKind.oneof_any:
+          of Oneof_fieldKind.oneof_any:
             oneof_any* {.fieldNumber: 11.}: seq[byte]
 
         TestOneOf* {.proto3.} = object
           pre* {.fieldNumber: 1, pint.}: int32
-          oneof_field* {.oneof.}: TestOneOfOneof_field
+          oneof_field* {.oneof.}: Oneof_field
           post* {.fieldNumber: 2, pint.}: int32
 
         ErrorStatus* {.proto3.} = object

--- a/tests/files/to_test.proto3
+++ b/tests/files/to_test.proto3
@@ -65,3 +65,11 @@ message Result {
 message SomeOtherMessage {
   SearchResponse.Result result = 1;
 }
+
+//oneof produces a Result object; clashes with outter Result message
+message OneOfMessage {
+  oneof result {
+    string foo = 1;
+    string bar = 2;
+  }
+}


### PR DESCRIPTION
I think the half-baked namespacing done in #70 for generated import_proto3 oneof types+enums will probably complicate matters when trying to namespace properly and so it's removed here. Removing the namespacing may produce clashes, but so does nested messages and enums currently.

Breaking change. I could add a param to keep current behavior, but consider adding oneof support itself was a breaking change as well...

Ref: #95