### PR TITLE
revert #94: import_proto3: remove oneof namespace

### DIFF
--- a/protobuf_serialization/files/type_generator.nim
+++ b/protobuf_serialization/files/type_generator.nim
@@ -135,7 +135,7 @@ proc protoToTypesInternalImpl(filepath: string, isProto3 = true, protoHook: Prot
             # Oneof does not allow: map, repeated, optional
             let field = ProtoNode(
               kind: ProtoType.Oneof,
-              oneofName: field.oneofName.capitalizeAscii(),
+              oneofName: msg.messageName & field.oneofName.capitalizeAscii(),
               oneof: field.oneof
             )
             queue.add(field)
@@ -250,7 +250,7 @@ proc protoToTypesInternalImpl(filepath: string, isProto3 = true, protoHook: Prot
                 ),
                 newNimNode(nnkPragma).add(ident("oneof"))
               ),
-              ident(field.oneofName.capitalizeAscii()),
+              ident(next.messageName & field.oneofName.capitalizeAscii()),
               newEmptyNode()
             ))
           of ProtoType.Field:

--- a/tests/conformance/conformance_nim.nim
+++ b/tests/conformance/conformance_nim.nim
@@ -34,15 +34,15 @@ template processPayload(payload, DecodeType): untyped =
     let x = Protobuf.decode(payload, DecodeType)
     try:
       ConformanceResponse(
-        result: Result(
-          kind: ResultKind.protobuf_payload,
+        result: ConformanceResponseResult(
+          kind: ConformanceResponseResultKind.protobuf_payload,
           protobuf_payload: Protobuf.encode(x)
         )
       )
     except ProtobufError as exc:
       ConformanceResponse(
-        result: Result(
-          kind: ResultKind.serialize_error,
+        result: ConformanceResponseResult(
+          kind: ConformanceResponseResultKind.serialize_error,
           serialize_error: "serialize_error: " & exc.msg
         )
       )
@@ -50,18 +50,18 @@ template processPayload(payload, DecodeType): untyped =
   #  ConformanceResponse(skipped: "skipped: " & exc.msg)
   except ProtobufError as exc:
       ConformanceResponse(
-        result: Result(
-          kind: ResultKind.parse_error,
+        result: ConformanceResponseResult(
+          kind: ConformanceResponseResultKind.parse_error,
           parse_error: "parse_error: " & exc.msg
         )
       )
 
 proc doTest(request: ConformanceRequest): ConformanceResponse =
   if request.requested_output_format != WireFormat.PROTOBUF or
-      request.payload.kind != PayloadKind.protobuf_payload:
+      request.payload.kind != ConformanceRequestPayloadKind.protobuf_payload:
     ConformanceResponse(
-      result: Result(
-        kind: ResultKind.skipped,
+      result: ConformanceResponseResult(
+        kind: ConformanceResponseResultKind.skipped,
         skipped: "skip not protobuf"
       )
     )
@@ -71,8 +71,8 @@ proc doTest(request: ConformanceRequest): ConformanceResponse =
     processPayload(request.payload.protobuf_payload, TestAllTypesProto2)
   else:
     ConformanceResponse(
-      result: Result(
-        kind: ResultKind.skipped,
+      result: ConformanceResponseResult(
+        kind: ConformanceResponseResultKind.skipped,
         skipped: "skip unknown message type: " & request.message_type
       )
     )

--- a/tests/test_proto_file.nim
+++ b/tests/test_proto_file.nim
@@ -87,8 +87,7 @@ suite "Test proto file import":
         TestMessage* {.proto3.} = object
           map_string_bytes* {.fieldNumber: 1.}: seq[Map_string_bytesEntry]
 
-
-        Oneof_fieldKind* {.pure, proto3.} = enum
+        TestOneOfOneof_fieldKind* {.pure, proto3.} = enum
           notSet = 0
           oneof_uint32 = 1
           oneof_string = 2
@@ -100,32 +99,32 @@ suite "Test proto file import":
           oneof_enum = 8
           oneof_any = 9
 
-        Oneof_field* {.proto3, oneof.} = object
-          case kind*: Oneof_fieldKind
-          of Oneof_fieldKind.notSet:
+        TestOneOfOneof_field* {.proto3, oneof.} = object
+          case kind*: TestOneOfOneof_fieldKind
+          of TestOneOfOneof_fieldKind.notSet:
             discard
-          of Oneof_fieldKind.oneof_uint32:
+          of TestOneOfOneof_fieldKind.oneof_uint32:
             oneof_uint32* {.fieldNumber: 3, pint.}: uint32
-          of Oneof_fieldKind.oneof_string:
+          of TestOneOfOneof_fieldKind.oneof_string:
             oneof_string* {.fieldNumber: 4.}: string
-          of Oneof_fieldKind.oneof_bytes:
+          of TestOneOfOneof_fieldKind.oneof_bytes:
             oneof_bytes* {.fieldNumber: 5.}: seq[byte]
-          of Oneof_fieldKind.oneof_bool:
+          of TestOneOfOneof_fieldKind.oneof_bool:
             oneof_bool* {.fieldNumber: 6.}: bool
-          of Oneof_fieldKind.oneof_uint64:
+          of TestOneOfOneof_fieldKind.oneof_uint64:
             oneof_uint64* {.fieldNumber: 7, pint.}: uint64
-          of Oneof_fieldKind.oneof_float:
+          of TestOneOfOneof_fieldKind.oneof_float:
             oneof_float* {.fieldNumber: 8.}: float32
-          of Oneof_fieldKind.oneof_double:
+          of TestOneOfOneof_fieldKind.oneof_double:
             oneof_double* {.fieldNumber: 9.}: float64
-          of Oneof_fieldKind.oneof_enum:
+          of TestOneOfOneof_fieldKind.oneof_enum:
             oneof_enum* {.fieldNumber: 10, ext.}: TestEnum
-          of Oneof_fieldKind.oneof_any:
+          of TestOneOfOneof_fieldKind.oneof_any:
             oneof_any* {.fieldNumber: 11.}: seq[byte]
 
         TestOneOf* {.proto3.} = object
           pre* {.fieldNumber: 1, pint.}: int32
-          oneof_field* {.oneof.}: Oneof_field
+          oneof_field* {.oneof.}: TestOneOfOneof_field
           post* {.fieldNumber: 2, pint.}: int32
 
         ErrorStatus* {.proto3.} = object


### PR DESCRIPTION
revert #94

it seems it's common to repeat oneof field names like `oneof result {}`, `oneof payload {}`, etc and cause a clash.

maybe revisit after #95