### PR TITLE
import_proto3: fix deeply nested messages

### DIFF
--- a/protobuf_serialization/files/type_generator.nim
+++ b/protobuf_serialization/files/type_generator.nim
@@ -114,8 +114,9 @@ proc isNested(base: string, currentName: string, messages: seq[ProtoNode]): bool
   isNested(base, currentName, messages, seen)
 
 proc addMessage(messages: var seq[ProtoNode], msg: ProtoNode) =
-  if msg.kind != ProtoType.Message:
+  if msg.kind == ProtoType.Extend:
     return
+  doAssert msg.kind == ProtoType.Message, $msg.kind
   for nestee in msg.nested:
     addMessage(messages, nestee)
   messages.add(msg)

--- a/protobuf_serialization/files/type_generator.nim
+++ b/protobuf_serialization/files/type_generator.nim
@@ -114,7 +114,8 @@ proc isNested(base: string, currentName: string, messages: seq[ProtoNode]): bool
   isNested(base, currentName, messages, seen)
 
 proc addMessage(messages: var seq[ProtoNode], msg: ProtoNode) =
-  doAssert msg.kind == ProtoType.Message, $msg.kind
+  if msg.kind != ProtoType.Message:
+    return
   for nestee in msg.nested:
     addMessage(messages, nestee)
   messages.add(msg)

--- a/protobuf_serialization/files/type_generator.nim
+++ b/protobuf_serialization/files/type_generator.nim
@@ -113,239 +113,240 @@ proc isNested(base: string, currentName: string, messages: seq[ProtoNode]): bool
   var seen = default(seq[ProtoNode])
   isNested(base, currentName, messages, seen)
 
+proc addMessage(messages: var seq[ProtoNode], msg: ProtoNode) =
+  doAssert msg.kind == ProtoType.Message, $msg.kind
+  for nestee in msg.nested:
+    addMessage(messages, nestee)
+  messages.add(msg)
+
 proc protoToTypesInternalImpl(filepath: string, isProto3 = true, protoHook: ProtoHook = nil): NimNode {.compileTime.} =
   var
-    packages: seq[ProtoNode] = parseProtobuf(filepath).packages
-    queue: seq[ProtoNode] = @[]
+    packages = parseProtobuf(filepath).packages
+    messages = newSeq[ProtoNode]()
+    enums = newSeq[ProtoNode]()
+    oneofs = newSeq[ProtoNode]()
+    maps = newSeq[ProtoNode]()
     enumNames = initHashSet[string]()
     typeSection = newNimNode(nnkTypeSection)
-  for parsed in packages:
-    for msg in parsed.messages:
-      if msg.kind != ProtoType.Extend:
-        for pbEnum in msg.definedEnums:
-          enumNames.incl pbEnum.enumName
-    for pbEnum in parsed.packageEnums:
-      enumNames.incl pbEnum.enumName
-  for parsed in packages:
-    for msg in parsed.messages:
-      queue.add(msg)
-      if msg.kind != ProtoType.Extend:
-        for field in msg.fields:
-          if field.kind == ProtoType.Oneof:
-            # Oneof does not allow: map, repeated, optional
-            let field = ProtoNode(
-              kind: ProtoType.Oneof,
-              oneofName: msg.messageName & field.oneofName.capitalizeAscii(),
-              oneof: field.oneof
-            )
-            queue.add(field)
-            # Add oneof case field enum
-            var enumVals = @[ProtoNode(kind: ProtoType.EnumVal, fieldName: "notSet", num: 0)]
-            for i, f in field.oneof.pairs():
-              doAssert f.kind == ProtoType.Field, $f.kind
-              enumVals.add ProtoNode(kind: ProtoType.EnumVal, fieldName: f.name, num: i + 1)
-            queue.add ProtoNode(
-              kind: ProtoType.Enum,
-              enumName: field.oneofName & "Kind",
-              values: enumVals
-            )
-          elif field.kind == ProtoType.Field and field.protoType.startsWith("map<"):
-            let matches = field.protoType.split({'<', '>', ','})
-            let entryFields = @[
-              ProtoNode(kind: ProtoType.Field, number: 1, protoType: matches[1], name: "key"),
-              ProtoNode(kind: ProtoType.Field, number: 2, protoType: matches[2], name: "value")
-            ]
-            queue.add ProtoNode(
-              kind: Message,
-              messageName: field.name.capitalizeAscii() & "Entry",
-              fields: entryFields)
-      # TODO: define Enums first to workaround https://github.com/nim-lang/Nim/issues/25651
-      if msg.kind != ProtoType.Extend:
-        for pbEnum in msg.definedEnums:
-          queue.add(pbEnum)
-        for nestee in msg.nested:
-          queue.add(nestee)
-    for pbEnum in parsed.packageEnums:
-      queue.add(pbEnum)
 
-    while queue.len != 0:
-      var
-        next: ProtoNode = queue.pop()
-        name: string
-        value: NimNode
-      if next.kind == ProtoType.Enum:
-        # TODO: allow_alias
-        var alreadySeen: seq[int] = @[]
-        name = next.enumName
-        value = newNimNode(nnkEnumTy).add(newEmptyNode())
-        for enumField in next.values.sortedByIt(it.num):
-          if enumField.num in alreadySeen:
-            continue
-          alreadySeen.add(enumField.num)
-          value.add(newNimNode(nnkEnumFieldDef).add(
-            ident(enumField.fieldName),
-            newIntLitNode(enumField.num)
-          ))
-      elif next.kind == ProtoType.Oneof:
-        name = next.oneofName
-        let caseKind = ident(name & "Kind")
-        let caseOf = newNimNode(nnkRecCase).add(
-          newIdentDefs(newNimNode(nnkPostfix).add(ident("*"), ident("kind")), caseKind),
-          newNimNode(nnkOfBranch).add(
-            newDotExpr(caseKind, ident"notSet"),
-            newNimNode(nnkRecList).add(newNilLit())
-          )
+  # TODO: nodes ordered by enums, maps, oneofs, messages to workaround https://github.com/nim-lang/Nim/issues/25651
+  # TODO: order in topological sort / message dependency order
+  for pkg in packages:
+    for pbEnum in pkg.packageEnums:
+      doAssert pbEnum.kind == ProtoType.Enum
+      enums.add(pbEnum)
+    for msg in pkg.messages:
+      if msg.kind == ProtoType.Message:
+        messages.addMessage msg
+  for msg in messages:
+    for pbEnum in msg.definedEnums:
+      doAssert pbEnum.kind == ProtoType.Enum
+      enums.add(pbEnum)
+    for field in msg.fields:
+      if field.kind == ProtoType.Oneof:
+        # Oneof does not allow: map, repeated, optional
+        let field = ProtoNode(
+          kind: ProtoType.Oneof,
+          oneofName: msg.messageName & field.oneofName.capitalizeAscii(),
+          oneof: field.oneof
         )
-        for field in next.oneof:
-          doAssert field.kind == ProtoType.Field, $field.kind
-          let (typ, pragma) = if field.protoType == "google.protobuf.Any":
-            getTypeAndPragma("bytes")
-          else:
-            getTypeAndPragma(field.protoType)
-          var pragmas = default(seq[NimNode])
-          if not pragma.isNil():
-            pragmas.add pragma
-          if field.protoType.split('.')[^1] in enumNames:
-            pragmas.add ident"ext"
-          caseOf.add(
-            newNimNode(nnkOfBranch).add(
-              newDotExpr(caseKind, ident(field.name)),
-              newNimNode(nnkRecList).add(newIdentDefs(
-                newNimNode(nnkPragmaExpr).add(
-                  newNimNode(nnkPostfix).add(ident("*"), ident(field.name)),
-                  newNimNode(nnkPragma).add(
-                    newNimNode(nnkExprColonExpr).add(ident("fieldNumber"), newIntLitNode(field.number))
-                  ).add(pragmas)
-                ),
-                typ
-              ))
-            )
-          )
-        value = newNimNode(nnkObjectTy).add(
-          newEmptyNode(),
-          newEmptyNode(),
-          newNimNode(nnkRecList).add(caseOf)
+        var enumVals = @[ProtoNode(kind: ProtoType.EnumVal, fieldName: "notSet", num: 0)]
+        for i, f in field.oneof.pairs():
+          doAssert f.kind == ProtoType.Field, $f.kind
+          enumVals.add ProtoNode(kind: ProtoType.EnumVal, fieldName: f.name, num: i + 1)
+        oneofs.add ProtoNode(
+          kind: ProtoType.Enum,
+          enumName: field.oneofName & "Kind",
+          values: enumVals
         )
-      else:
-        if next.kind == ProtoType.Extend:
+        oneofs.add(field)
+      elif field.kind == ProtoType.Field and field.protoType.startsWith("map<"):
+        let matches = field.protoType.split({'<', '>', ','})
+        let entryFields = @[
+          ProtoNode(kind: ProtoType.Field, number: 1, protoType: matches[1], name: "key"),
+          ProtoNode(kind: ProtoType.Field, number: 2, protoType: matches[2], name: "value")
+        ]
+        maps.add ProtoNode(
+          kind: Message,
+          messageName: field.name.capitalizeAscii() & "Entry",
+          fields: entryFields)
+
+  for pbEnum in enums:
+    enumNames.incl pbEnum.enumName
+
+  for node in enums & maps & oneofs & messages:
+    var name: string
+    var value: NimNode
+    case node.kind
+    of ProtoType.Enum:
+      # TODO: allow_alias
+      var alreadySeen: seq[int] = @[]
+      name = node.enumName
+      value = newNimNode(nnkEnumTy).add(newEmptyNode())
+      for enumField in node.values.sortedByIt(it.num):
+        if enumField.num in alreadySeen:
           continue
-        #if (next.definedEnums.len != 0) or (next.nested.len != 0):
-        #  for nestee in (next.definedEnums & next.nested):
-        #    queue.add(nestee)
-
-        name = next.messageName
-        value = newNimNode(nnkObjectTy).add(
-          newEmptyNode(),
-          newEmptyNode(),
-          newNimNode(nnkRecList)
-        )
-        for field in next.fields:
-          case field.kind
-          of ProtoType.Oneof:
-            value[2].add(newNimNode(nnkIdentDefs).add(
-              newNimNode(nnkPragmaExpr).add(
-                newNimNode(nnkPostfix).add(
-                  ident("*"),
-                  ident(field.oneofName)
-                ),
-                newNimNode(nnkPragma).add(ident("oneof"))
-              ),
-              ident(next.messageName & field.oneofName.capitalizeAscii()),
-              newEmptyNode()
-            ))
-          of ProtoType.Field:
-            value[2].add(newNimNode(nnkIdentDefs).add(
-              newNimNode(nnkPragmaExpr).add(
-                newNimNode(nnkPostfix).add(
-                  ident("*"),
-                  ident(field.name)
-                ),
-                newNimNode(nnkPragma).add(
-                  newNimNode(nnkExprColonExpr).add(
-                    ident("fieldNumber"),
-                    newIntLitNode(field.number)
-                  )
-                )
-              ),
-              ident(if field.protoType == "google.protobuf.Any": "bytes" else: field.protoType),
-              newEmptyNode()
-            ))
-
-            var isReference = false
-            for parsed in packages:
-              if next.messageName.isNested(field.protoType, parsed.messages):
-                isReference = true
-                break
-
-            if value[2][^1][1].strVal.startsWith("map<"):
-              value[2][^1][1] = newNimNode(nnkBracketExpr).add(
-                ident("seq"), ident(field.name.capitalizeAscii() & "Entry")
-              )
-            else:
-              let (typ, pragma) = getTypeAndPragma(value[2][^1][1].strVal)
-              value[2][^1][1] = typ
-              if not pragma.isNil():
-                value[2][^1][0][1].add(pragma)
-
-            # XXX fix namespaces
-            if field.protoType.split('.')[^1] in enumNames:
-              value[2][^1][0][1].add ident"ext"
-
-            if field.presence == Optional and not isProto3:
-              var optDefault = ""
-              for opt in field.options:
-                if opt.optName == "default":
-                  optDefault = opt.optVal
-              let typ = value[2][^1][1]
-              let innerTyp = if optDefault.len > 0:
-                parseDefault(optDefault, typ)
-              else:
-                quote do: default(`typ`)
-              value[2][^1][1] = quote do: PBOption[`innerTyp`]
-
-            for opt in field.options:
-              if opt.optName == "packed" and opt.optVal in ["true", "false"]:
-                value[2][^1][0][1].add(
-                  newNimNode(nnkExprColonExpr).add(
-                    ident(opt.optName),
-                    newLitFixed(opt.optVal == "true")
-                  )
-                )
-
-            if field.presence == Repeated:
-              value[2][^1][1] = newNimNode(nnkBracketExpr).add(
-                ident("seq"),
-                value[2][^1][1]
-              )
-            elif isReference:
-              value[2][^1][1] = newNimNode(nnkRefTy).add(value[2][^1][1])
-          else:
-            raiseAssert "Unexpected proto type: " & $field.kind
-
-        # Empty message
-        if value[2].len == 0:
-          value[2] = newEmptyNode()
-
-      let protoVer = if isProto3:
-        "proto3"
-      else:
-        "proto2"
-
-      typeSection.add(
-        newNimNode(nnkTypeDef).add(
-          newNimNode(nnkPragmaExpr).add(
-            newNimNode(nnkPostfix).add(ident("*"), ident(name)),
-            if next.kind == ProtoType.Enum:
-              newNimNode(nnkPragma).add(ident("pure"), ident(protoVer))
-            elif next.kind == ProtoType.Oneof:
-              newNimNode(nnkPragma).add(ident(protoVer), ident("oneof"))
-            else:
-              newNimNode(nnkPragma).add(ident(protoVer))
-          ),
-          newEmptyNode(),
-          value
+        alreadySeen.add(enumField.num)
+        value.add(newNimNode(nnkEnumFieldDef).add(
+          ident(enumField.fieldName),
+          newIntLitNode(enumField.num)
+        ))
+    of ProtoType.Oneof:
+      name = node.oneofName
+      let caseKind = ident(name & "Kind")
+      let caseOf = newNimNode(nnkRecCase).add(
+        newIdentDefs(newNimNode(nnkPostfix).add(ident("*"), ident("kind")), caseKind),
+        newNimNode(nnkOfBranch).add(
+          newDotExpr(caseKind, ident"notSet"),
+          newNimNode(nnkRecList).add(newNilLit())
         )
       )
+      for field in node.oneof:
+        doAssert field.kind == ProtoType.Field, $field.kind
+        let (typ, pragma) = if field.protoType == "google.protobuf.Any":
+          getTypeAndPragma("bytes")
+        else:
+          getTypeAndPragma(field.protoType)
+        var pragmas = default(seq[NimNode])
+        if not pragma.isNil():
+          pragmas.add pragma
+        if field.protoType.split('.')[^1] in enumNames:
+          pragmas.add ident"ext"
+        caseOf.add(
+          newNimNode(nnkOfBranch).add(
+            newDotExpr(caseKind, ident(field.name)),
+            newNimNode(nnkRecList).add(newIdentDefs(
+              newNimNode(nnkPragmaExpr).add(
+                newNimNode(nnkPostfix).add(ident("*"), ident(field.name)),
+                newNimNode(nnkPragma).add(
+                  newNimNode(nnkExprColonExpr).add(ident("fieldNumber"), newIntLitNode(field.number))
+                ).add(pragmas)
+              ),
+              typ
+            ))
+          )
+        )
+      value = newNimNode(nnkObjectTy).add(
+        newEmptyNode(),
+        newEmptyNode(),
+        newNimNode(nnkRecList).add(caseOf)
+      )
+    of ProtoType.Message:
+      name = node.messageName
+      value = newNimNode(nnkObjectTy).add(
+        newEmptyNode(),
+        newEmptyNode(),
+        newNimNode(nnkRecList)
+      )
+      for field in node.fields:
+        case field.kind
+        of ProtoType.Oneof:
+          value[2].add(newNimNode(nnkIdentDefs).add(
+            newNimNode(nnkPragmaExpr).add(
+              newNimNode(nnkPostfix).add(
+                ident("*"),
+                ident(field.oneofName)
+              ),
+              newNimNode(nnkPragma).add(ident("oneof"))
+            ),
+            ident(node.messageName & field.oneofName.capitalizeAscii()),
+            newEmptyNode()
+          ))
+        of ProtoType.Field:
+          value[2].add(newNimNode(nnkIdentDefs).add(
+            newNimNode(nnkPragmaExpr).add(
+              newNimNode(nnkPostfix).add(
+                ident("*"),
+                ident(field.name)
+              ),
+              newNimNode(nnkPragma).add(
+                newNimNode(nnkExprColonExpr).add(
+                  ident("fieldNumber"),
+                  newIntLitNode(field.number)
+                )
+              )
+            ),
+            ident(if field.protoType == "google.protobuf.Any": "bytes" else: field.protoType),
+            newEmptyNode()
+          ))
+
+          var isReference = false
+          for parsed in packages:
+            if node.messageName.isNested(field.protoType, parsed.messages):
+              isReference = true
+              break
+
+          if value[2][^1][1].strVal.startsWith("map<"):
+            value[2][^1][1] = newNimNode(nnkBracketExpr).add(
+              ident("seq"), ident(field.name.capitalizeAscii() & "Entry")
+            )
+          else:
+            let (typ, pragma) = getTypeAndPragma(value[2][^1][1].strVal)
+            value[2][^1][1] = typ
+            if not pragma.isNil():
+              value[2][^1][0][1].add(pragma)
+
+          # XXX fix namespaces
+          if field.protoType.split('.')[^1] in enumNames:
+            value[2][^1][0][1].add ident"ext"
+
+          if field.presence == Optional and not isProto3:
+            var optDefault = ""
+            for opt in field.options:
+              if opt.optName == "default":
+                optDefault = opt.optVal
+            let typ = value[2][^1][1]
+            let innerTyp = if optDefault.len > 0:
+              parseDefault(optDefault, typ)
+            else:
+              quote do: default(`typ`)
+            value[2][^1][1] = quote do: PBOption[`innerTyp`]
+
+          for opt in field.options:
+            if opt.optName == "packed" and opt.optVal in ["true", "false"]:
+              value[2][^1][0][1].add(
+                newNimNode(nnkExprColonExpr).add(
+                  ident(opt.optName),
+                  newLitFixed(opt.optVal == "true")
+                )
+              )
+
+          if field.presence == Repeated:
+            value[2][^1][1] = newNimNode(nnkBracketExpr).add(
+              ident("seq"),
+              value[2][^1][1]
+            )
+          elif isReference:
+            value[2][^1][1] = newNimNode(nnkRefTy).add(value[2][^1][1])
+        else:
+          raiseAssert "Unexpected proto type: " & $field.kind
+
+      # Empty message
+      if value[2].len == 0:
+        value[2] = newEmptyNode()
+    else:
+      raiseAssert "Unhandled proto node " & $node.kind
+
+    let protoVer = if isProto3:
+      "proto3"
+    else:
+      "proto2"
+
+    typeSection.add(
+      newNimNode(nnkTypeDef).add(
+        newNimNode(nnkPragmaExpr).add(
+          newNimNode(nnkPostfix).add(ident("*"), ident(name)),
+          if node.kind == ProtoType.Enum:
+            newNimNode(nnkPragma).add(ident("pure"), ident(protoVer))
+          elif node.kind == ProtoType.Oneof:
+            newNimNode(nnkPragma).add(ident(protoVer), ident("oneof"))
+          else:
+            newNimNode(nnkPragma).add(ident(protoVer))
+        ),
+        newEmptyNode(),
+        value
+      )
+    )
   result = if protoHook != nil:
     let n = protoHook(packages)
     if n.kind == nnkStmtList:

--- a/tests/conformance/test_messages_proto2.proto
+++ b/tests/conformance/test_messages_proto2.proto
@@ -47,6 +47,10 @@ option optimize_for = SPEED;
 
 option cc_enable_arenas = true;
 
+message ForeignMessageProto2 {
+  optional int32 c = 1;
+}
+
 // This proto includes every type of field in both singular and repeated
 // forms.
 //
@@ -277,10 +281,6 @@ message UnknownToTestAllTypes {
   // }
   optional bool optional_bool = 1006;
   repeated int32 repeated_int32 = 1011;
-}
-
-message ForeignMessageProto2 {
-  optional int32 c = 1;
 }
 
 message NullHypothesisProto2 {}

--- a/tests/test_proto_file.nim
+++ b/tests/test_proto_file.nim
@@ -168,9 +168,9 @@ suite "Test proto file import":
         ThirdLevel* {.proto3.} = object
           myenum* {.fieldNumber: 1, ext.}: MyEnum
         SecondLevel* {.proto3.} = object
-          result* {.fieldNumber: 1.}: ThirdLevel
+          b* {.fieldNumber: 1.}: ThirdLevel
         FirstLevel* {.proto3.} = object
-          result* {.fieldNumber: 1.}: SecondLevel
+          a* {.fieldNumber: 1.}: SecondLevel
     checkProtoFile("test_proto_file_nested.proto3", expected)
 
   staticTest "test_proto_file_services.proto3 file":

--- a/tests/test_proto_file.nim
+++ b/tests/test_proto_file.nim
@@ -10,7 +10,9 @@
 import 
   std/[macros, os, strutils],
   unittest2,
+  ./utils,
   ../protobuf_serialization,
+  ../protobuf_serialization/std/enums,
   ../protobuf_serialization/files/type_generator
 
 proc fixAst(ast: NimNode): NimNode =
@@ -80,12 +82,18 @@ suite "Test proto file import":
           UNKNOWN = 0
           STARTED = 1
 
+        Corpus* {.pure, proto3.} = enum
+          UNIVERSAL = 0
+          WEB = 1
+          IMAGES = 2
+          LOCAL = 3
+          NEWS = 4
+          PRODUCTS = 5
+          VIDEO = 6
+
         Map_string_bytesEntry* {.proto3.} = object
           key* {.fieldNumber: 1.}: string
           value* {.fieldNumber: 2.}: seq[byte]
-
-        TestMessage* {.proto3.} = object
-          map_string_bytes* {.fieldNumber: 1.}: seq[Map_string_bytesEntry]
 
         TestOneOfOneof_fieldKind* {.pure, proto3.} = enum
           notSet = 0
@@ -122,14 +130,13 @@ suite "Test proto file import":
           of TestOneOfOneof_fieldKind.oneof_any:
             oneof_any* {.fieldNumber: 11.}: seq[byte]
 
-        TestOneOf* {.proto3.} = object
-          pre* {.fieldNumber: 1, pint.}: int32
-          oneof_field* {.oneof.}: TestOneOfOneof_field
-          post* {.fieldNumber: 2, pint.}: int32
+        Foo* {.proto3.} = object
 
-        ErrorStatus* {.proto3.} = object
-          message* {.fieldNumber: 1.}: string
-          details* {.fieldNumber: 2.}: seq[seq[byte]]
+        SearchRequest* {.proto3.} = object
+          query* {.fieldNumber: 1.}: string
+          page_number* {.fieldNumber: 2, pint.}: int32
+          result_per_page* {.fieldNumber: 3, pint.}: int32
+          corpus* {.fieldNumber: 4, ext.}: Corpus
 
         Result* {.proto3.} = object
           url* {.fieldNumber: 1.}: string
@@ -139,45 +146,53 @@ suite "Test proto file import":
         SearchResponse* {.proto3.} = object
           results* {.fieldNumber: 1.}: seq[Result]
 
-        Corpus* {.pure, proto3.} = enum
-          UNIVERSAL = 0
-          WEB = 1
-          IMAGES = 2
-          LOCAL = 3
-          NEWS = 4
-          PRODUCTS = 5
-          VIDEO = 6
+        ErrorStatus* {.proto3.} = object
+          message* {.fieldNumber: 1.}: string
+          details* {.fieldNumber: 2.}: seq[seq[byte]]
 
-        SearchRequest* {.proto3.} = object
-          query* {.fieldNumber: 1.}: string
-          page_number* {.fieldNumber: 2, pint.}: int32
-          result_per_page* {.fieldNumber: 3, pint.}: int32
-          corpus* {.fieldNumber: 4, ext.}: Corpus
+        TestOneOf* {.proto3.} = object
+          pre* {.fieldNumber: 1, pint.}: int32
+          oneof_field* {.oneof.}: TestOneOfOneof_field
+          post* {.fieldNumber: 2, pint.}: int32
 
-        Foo* {.proto3.} = object
+        TestMessage* {.proto3.} = object
+          map_string_bytes* {.fieldNumber: 1.}: seq[Map_string_bytesEntry]
 
     checkProtoFile("test_proto_file_test.proto3", expected)
+
+  staticTest "test_proto_file_nested.proto3 file":
+    let expected = quote do:
+      type
+        MyEnum* {.pure, proto3.} = enum
+          Foo = 0
+        ThirdLevel* {.proto3.} = object
+          myenum* {.fieldNumber: 1, ext.}: MyEnum
+        SecondLevel* {.proto3.} = object
+          result* {.fieldNumber: 1.}: ThirdLevel
+        FirstLevel* {.proto3.} = object
+          result* {.fieldNumber: 1.}: SecondLevel
+    checkProtoFile("test_proto_file_nested.proto3", expected)
 
   staticTest "test_proto_file_services.proto3 file":
     let expected = quote do:
       type
-        HealthResponse* {.proto3.} = object
-          status* {.fieldNumber: 1, pint.}: int32
-
-        HealthRequest* {.proto3.} = object
-          timeout* {.fieldNumber: 1, pint.}: int32
-
-        DiscoverResponse* {.proto3.} = object
-          url* {.fieldNumber: 1.}: string
-
-        DiscoverRequest* {.proto3.} = object
+        SearchRequest* {.proto3.} = object
           query* {.fieldNumber: 1.}: string
 
         SearchResponse* {.proto3.} = object
           url* {.fieldNumber: 1.}: string
 
-        SearchRequest* {.proto3.} = object
+        DiscoverRequest* {.proto3.} = object
           query* {.fieldNumber: 1.}: string
+
+        DiscoverResponse* {.proto3.} = object
+          url* {.fieldNumber: 1.}: string
+
+        HealthRequest* {.proto3.} = object
+          timeout* {.fieldNumber: 1, pint.}: int32
+
+        HealthResponse* {.proto3.} = object
+          status* {.fieldNumber: 1, pint.}: int32
 
       proc testSearchServiceSearch*(req: SearchRequest): SearchResponse
       proc testSearchServiceHealth*(req: HealthRequest): HealthResponse
@@ -192,16 +207,17 @@ suite "Test proto file import":
     checkProtoFile("test_proto_file_services.proto3", expected, protoHook = serviceHook)
 
 import_proto3 "test_proto_file_test.proto3"
+import_proto3 "test_proto_file_nested.proto3"
 
 suite "Test proto generated types":
-  test "response object":
-    check(
-      Protobuf.supports(TestEnum) and
-      Protobuf.supports(TestOneOf) and
-      Protobuf.supports(ErrorStatus) and
-      Protobuf.supports(Result) and
-      Protobuf.supports(SearchResponse) and
-      Protobuf.supports(Corpus) and
-      Protobuf.supports(SearchRequest) and
-      Protobuf.supports(Foo)
-    )
+  test "test_proto_file_test.proto3 roundtrip":
+    roundtrip(ErrorStatus(), "")
+    roundtrip(Result(), "")
+    roundtrip(SearchResponse(), "")
+    roundtrip(SearchRequest(), "")
+    roundtrip(Foo(), "")
+    roundtrip(TestMessage(), "")
+    discard Protobuf.encode(TestOneOf())
+
+  test "test_proto_file_nested.proto3 roundtrip":
+    roundtrip(FirstLevel(), "")

--- a/tests/test_proto_file_nested.proto3
+++ b/tests/test_proto_file_nested.proto3
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+message FirstLevel {
+  message SecondLevel {
+    message ThirdLevel {
+      enum MyEnum {
+        Foo = 0;
+      }
+      MyEnum myenum = 1;
+    }
+    ThirdLevel result = 1;
+  }
+  SecondLevel result = 1;
+}

--- a/tests/test_proto_file_nested.proto3
+++ b/tests/test_proto_file_nested.proto3
@@ -8,7 +8,7 @@ message FirstLevel {
       }
       MyEnum myenum = 1;
     }
-    ThirdLevel result = 1;
+    ThirdLevel b = 1;
   }
-  SecondLevel result = 1;
+  SecondLevel a = 1;
 }


### PR DESCRIPTION
Changes:

- Fix deeply nested messages code gen; only first level was being generated.
- Follow type definition order closer to the proto file.