### PR TITLE
import_proto3: `optional` field support

### DIFF
--- a/protobuf_serialization/files/type_generator.nim
+++ b/protobuf_serialization/files/type_generator.nim
@@ -292,17 +292,31 @@ proc protoToTypesInternalImpl(filepath: string, isProto3 = true, protoHook: Prot
           if field.protoType.split('.')[^1] in enumNames:
             value[2][^1][0][1].add ident"ext"
 
-          if field.presence == Optional and not isProto3:
-            var optDefault = ""
-            for opt in field.options:
-              if opt.optName == "default":
-                optDefault = opt.optVal
-            let typ = value[2][^1][1]
-            let innerTyp = if optDefault.len > 0:
-              parseDefault(optDefault, typ)
+          value[2][^1][1] =
+            if field.presence == Optional:
+              if isProto3:
+                let typ = value[2][^1][1]
+                quote do: Opt[`typ`]
+              else:
+                var optDefault = ""
+                for opt in field.options:
+                  if opt.optName == "default":
+                    optDefault = opt.optVal
+                let typ = value[2][^1][1]
+                let innerTyp = if optDefault.len > 0:
+                  parseDefault(optDefault, typ)
+                else:
+                  quote do: default(`typ`)
+                quote do: PBOption[`innerTyp`]
+            elif field.presence == Repeated:
+              newNimNode(nnkBracketExpr).add(
+                ident("seq"),
+                value[2][^1][1]
+              )
+            elif isReference:
+              newNimNode(nnkRefTy).add(value[2][^1][1])
             else:
-              quote do: default(`typ`)
-            value[2][^1][1] = quote do: PBOption[`innerTyp`]
+              value[2][^1][1]
 
           for opt in field.options:
             if opt.optName == "packed" and opt.optVal in ["true", "false"]:
@@ -312,14 +326,6 @@ proc protoToTypesInternalImpl(filepath: string, isProto3 = true, protoHook: Prot
                   newLitFixed(opt.optVal == "true")
                 )
               )
-
-          if field.presence == Repeated:
-            value[2][^1][1] = newNimNode(nnkBracketExpr).add(
-              ident("seq"),
-              value[2][^1][1]
-            )
-          elif isReference:
-            value[2][^1][1] = newNimNode(nnkRefTy).add(value[2][^1][1])
         else:
           raiseAssert "Unexpected proto type: " & $field.kind
 

--- a/protobuf_serialization/files/type_generator.nim
+++ b/protobuf_serialization/files/type_generator.nim
@@ -8,11 +8,13 @@
 # those terms.
 
 import
-  std/[os, algorithm, strutils, tables, sets, macros],
+  std/[os, algorithm, strutils, sets, macros],
   stew/shims/macros as stewmacros,
+  ../pkg/results,
+  ../std/enums,
   ./[decldef, proto_parser]
 
-export decldef, tables
+export decldef, enums, results
 
 type
   ProtoHook* = proc (packages: seq[ProtoNode]): NimNode {.raises: [], gcsafe.}

--- a/protobuf_serialization/proto_parser.nim
+++ b/protobuf_serialization/proto_parser.nim
@@ -1,2 +1,2 @@
 import ./files/type_generator
-export protoToTypes, import_proto3
+export protoToTypes, import_proto3, enums, results

--- a/protobuf_serialization/proto_parser.nim
+++ b/protobuf_serialization/proto_parser.nim
@@ -1,2 +1,5 @@
 import ./files/type_generator
 export protoToTypes, import_proto3, enums, results
+
+when defined(ConformanceTest):
+  export protoToTypes2, import_proto2

--- a/tests/conformance/conformance_nim.nim
+++ b/tests/conformance/conformance_nim.nim
@@ -11,8 +11,7 @@ import
   std/os,
   stew/byteutils,
   ../../protobuf_serialization,
-  ../../protobuf_serialization/std/enums,
-  ../../protobuf_serialization/files/type_generator
+  ../../protobuf_serialization/proto_parser
 
 import_proto3 "../../conformance/conformance/conformance.proto"
 

--- a/tests/conformance/test_proto2.nim
+++ b/tests/conformance/test_proto2.nim
@@ -1,3 +1,3 @@
 import ../../protobuf_serialization
-import ../../protobuf_serialization/files/type_generator
+import ../../protobuf_serialization/proto_parser
 import_proto2 "test_messages_proto2.proto"

--- a/tests/conformance/test_proto3.nim
+++ b/tests/conformance/test_proto3.nim
@@ -1,3 +1,3 @@
 import ../../protobuf_serialization
-import ../../protobuf_serialization/files/type_generator
+import ../../protobuf_serialization/proto_parser
 import_proto3 "test_messages_proto3.proto"

--- a/tests/test_proto_file.nim
+++ b/tests/test_proto_file.nim
@@ -13,6 +13,7 @@ import
   ./utils,
   ../protobuf_serialization,
   ../protobuf_serialization/std/enums,
+  ../protobuf_serialization/pkg/results,
   ../protobuf_serialization/files/type_generator
 
 proc fixAst(ast: NimNode): NimNode =
@@ -68,13 +69,25 @@ proc serviceHook(packages: seq[ProtoNode]): NimNode =
         result.add quote do:
           const `rpcPathName`* = `rpcPathVal`
 
-proc checkProtoFile(protoFile: string, expected: NimNode, protoHook: ProtoHook = nil) =
+proc eqProto(protoFile: string, expected: NimNode, protoHook: ProtoHook = nil): bool =
   let gened = protoToTypesImpl(currentSourcePath.parentDir / protoFile, protoHook = protoHook)
-  if gened != expected.fixAst:
-    checkpoint("FAILED: Got: \n" & repr(gened) & "\nExpected: " & repr(expected.fixAst))
+  #echo treeRepr(gened)
+  #echo treeRepr(gened.fixAst)
+  #echo treeRepr(expected)
+  #echo treeRepr(expected.fixAst)
+  gened.fixAst == expected.fixAst
+
+proc checkProtoFile(protoFile: string, expected: NimNode, protoHook: ProtoHook = nil) =
+  if not eqProto(protoFile, expected, protoHook):
+    let gened = protoToTypesImpl(currentSourcePath.parentDir / protoFile, protoHook = protoHook)
+    checkpoint("FAILED: Got: \n" & repr(gened.fixAst) & "\nExpected: " & repr(expected.fixAst))
     fail()
 
 suite "Test proto file import":
+  staticTest "sanity check":
+    let expected = quote do: discard
+    check(not eqProto("test_proto_file_test.proto3", expected))
+
   staticTest "test_proto_file_test.proto3 file":
     let expected = quote do:
       type
@@ -160,6 +173,17 @@ suite "Test proto file import":
 
     checkProtoFile("test_proto_file_test.proto3", expected)
 
+  staticTest "test_proto_file_optional.proto3 file":
+    let expected = quote do:
+      type
+        OptFieldEnum* {.pure, proto3.} = enum
+          UNKNOWN = 0, STARTED = 1
+        OptFieldMessage* {.proto3.} = object
+          a* {.fieldNumber: 1, ext.}: Opt[OptFieldEnum]
+          b* {.fieldNumber: 2, pint.}: Opt[int64]
+          notOpt* {.fieldNumber: 3, pint.}: int64
+    checkProtoFile("test_proto_file_optional.proto3", expected)
+
   staticTest "test_proto_file_nested.proto3 file":
     let expected = quote do:
       type
@@ -208,6 +232,7 @@ suite "Test proto file import":
 
 import_proto3 "test_proto_file_test.proto3"
 import_proto3 "test_proto_file_nested.proto3"
+import_proto3 "test_proto_file_optional.proto3"
 
 suite "Test proto generated types":
   test "test_proto_file_test.proto3 roundtrip":
@@ -221,3 +246,6 @@ suite "Test proto generated types":
 
   test "test_proto_file_nested.proto3 roundtrip":
     roundtrip(FirstLevel(), "")
+
+  test "test_proto_file_optional.proto3 roundtrip":
+    roundtrip(OptFieldMessage(), "")

--- a/tests/test_proto_file_optional.proto3
+++ b/tests/test_proto_file_optional.proto3
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+enum OptFieldEnum {
+  UNKNOWN = 0;
+  STARTED = 1;
+}
+
+message OptFieldMessage {
+  optional OptFieldEnum a = 1;
+  optional int64 b = 2;
+  int64 notOpt = 3;
+}


### PR DESCRIPTION
Changes:

- Generate `Opt[T]` for proto3 optional fields.
- Add missing exports in proto_parser for enums and results